### PR TITLE
Fix runtime patch 35

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,12 @@ computed_likelihoods/
 .idea/
 *.iml
 
+# Test files
+test_imports.py
+IMPLEMENTATION_SUMMARY.md
+CODE_REVIEW_CHECKLIST.md
+QUICKSTART_STARTUP_SCRIPT.md
+
 # OS files
 .DS_Store
 Thumbs.db

--- a/docs/STARTUP_SCRIPT.md
+++ b/docs/STARTUP_SCRIPT.md
@@ -1,0 +1,163 @@
+# Startup Script Feature
+
+This document describes how to use VoxKit's configurable startup script feature, which allows you to execute a Python function on the first launch of the application.
+
+## Overview
+
+The startup script feature provides a mechanism to:
+- Run custom initialization code only on the **first launch** of VoxKit
+- Execute before any GUI stackers are initialized
+- Display a loading dialog ("Retrieving assets...") while the script runs
+- Track whether the app has been launched before using a flag file in the user's data directory
+
+## How It Works
+
+1. **First Launch Detection**: VoxKit checks for a `.first_launch_complete` flag file in the storage root (`~/.voxkit/`)
+2. **Script Execution**: If this is the first launch and a startup script is configured, it runs in a background thread
+3. **Loading Dialog**: A modal dialog displays "Retrieving assets..." while the script executes
+4. **Completion Tracking**: After successful execution, the flag file is created to prevent re-running on subsequent launches
+
+## Configuration
+
+To configure a startup script, edit `src/voxkit/config.py` and set the `STARTUP_SCRIPT` variable:
+
+```python
+from typing import Callable
+
+# Import your startup function
+from my_module import my_startup_function
+
+# Set the startup script (or None to disable)
+STARTUP_SCRIPT: Callable[[], None] | None = my_startup_function
+```
+
+## Example Usage
+
+See `example_startup_script.py` for a complete example:
+
+```python
+def example_startup_script():
+    """Example startup script that simulates downloading assets."""
+    print("[STARTUP] Running first-launch startup script...")
+    
+    # Your initialization code here
+    # e.g., download models, set up configuration, etc.
+    time.sleep(2)  # Simulate a 2-second operation
+    
+    print("[STARTUP] Assets retrieved successfully!")
+```
+
+To enable this example:
+
+1. Edit `src/voxkit/config.py`
+2. Import the example function:
+   ```python
+   from example_startup_script import example_startup_script
+   ```
+3. Set the configuration:
+   ```python
+   STARTUP_SCRIPT = example_startup_script
+   ```
+
+## API Reference
+
+### Storage Utilities (`voxkit.storage.utils`)
+
+#### `is_first_launch() -> bool`
+Check if this is the first launch of the application.
+
+**Returns:**
+- `True` if this is the first launch
+- `False` if the app has been launched before
+
+#### `mark_first_launch_complete() -> None`
+Mark the first launch as complete by creating a flag file.
+
+This is automatically called after successful startup script execution.
+
+### Startup Module (`voxkit.startup`)
+
+#### `execute_startup_script(script: Callable[[], None] | None, app: QApplication) -> None`
+Execute the startup script if this is the first launch.
+
+**Parameters:**
+- `script`: The startup script function to execute, or `None` to skip
+- `app`: The QApplication instance for event processing
+
+**Behavior:**
+- Does nothing if `script` is `None` or if it's not the first launch
+- Shows a loading dialog while the script runs
+- Marks first launch as complete after successful execution
+- Prints errors but still marks as complete to avoid infinite retries
+
+### GUI Components (`voxkit.gui.components`)
+
+#### `LoadingDialog(message: str, parent=None)`
+A modal loading dialog with a message and progress indicator.
+
+**Parameters:**
+- `message`: The message to display (default: "Loading...")
+- `parent`: Optional parent widget
+
+**Methods:**
+- `update_message(message: str)`: Update the displayed message
+
+## Testing First Launch Again
+
+If you want to test the first launch behavior again:
+
+1. Delete the flag file:
+   ```bash
+   rm ~/.voxkit/.first_launch_complete
+   ```
+2. Launch VoxKit again
+
+Or programmatically:
+```python
+from pathlib import Path
+from voxkit.storage.utils import get_storage_root
+
+flag_file = get_storage_root() / ".first_launch_complete"
+flag_file.unlink(missing_ok=True)
+```
+
+## Error Handling
+
+- If the startup script raises an exception, the error is printed to the console
+- The loading dialog is updated to show the error message
+- The first launch is still marked as complete to avoid infinite retries
+- The application continues to start normally
+
+## Integration Points
+
+The startup script runs in `main.py` after:
+1. QApplication is created
+2. The application style is set
+
+But before:
+1. The main window (`AlignmentGUI`) is created
+2. Any GUI stackers are initialized
+3. The window is shown
+
+This ensures that:
+- PyQt event loop is available for the loading dialog
+- No GUI components are initialized while assets are being retrieved
+- The user sees the loading dialog immediately on first launch
+
+## Use Cases
+
+Common use cases for startup scripts:
+
+1. **Download pre-trained models**: Download models from HuggingFace or other sources
+2. **Initialize database**: Set up local database schemas or initial data
+3. **Download assets**: Retrieve configuration files, dictionaries, or other resources
+4. **System checks**: Verify dependencies or system requirements
+5. **User onboarding**: Display welcome messages or setup wizards (though the loading dialog should stay simple)
+
+## Notes
+
+- The startup script runs synchronously (blocks the main thread until complete)
+- Keep the script focused and fast to avoid long startup times
+- Use the loading dialog message to communicate what's happening
+- The script only runs once per installation (per user data directory)
+- If you need to run setup again, delete the flag file manually

--- a/example_startup_script.py
+++ b/example_startup_script.py
@@ -1,0 +1,33 @@
+"""Example startup script for testing.
+
+This is an example of how to configure a startup script that will run
+on the first launch of VoxKit.
+
+To use this:
+1. Import the function in your config.py
+2. Set STARTUP_SCRIPT = example_startup_script
+"""
+
+import time
+
+
+def example_startup_script():
+    """Example startup script that simulates downloading assets.
+    
+    This function demonstrates what a startup script might do:
+    - Simulate downloading models or assets
+    - Set up initial configuration
+    - Perform one-time initialization
+    """
+    print("[STARTUP] Running first-launch startup script...")
+    
+    # Simulate downloading/preparing assets
+    time.sleep(2)  # Simulate a 2-second operation
+    
+    print("[STARTUP] Assets retrieved successfully!")
+    print("[STARTUP] First launch initialization complete.")
+
+
+if __name__ == "__main__":
+    # For testing the script directly
+    example_startup_script()

--- a/main.py
+++ b/main.py
@@ -36,8 +36,8 @@ if getattr(sys, 'frozen', False):
         if os.path.exists(platform_plugins):
             minimal_env['QT_QPA_PLATFORM_PLUGIN_PATH'] = platform_plugins
 
-    # Clear all environment variables
-    os.environ.clear()
+    # # Clear all environment variables
+    # os.environ.clear()
 
     # Set the minimal required ones
     for key, value in minimal_env.items():

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ faulthandler.enable()
 # Apply patches for frozen (PyInstaller) environment
 if getattr(sys, 'frozen', False):
     import _frozen_patch
-    
+
     # Define the minimal required environment
     minimal_env = {
         'HOME': os.environ.get('HOME') or os.path.expanduser('~'),
@@ -24,48 +24,41 @@ if getattr(sys, 'frozen', False):
         'TMPDIR': os.environ.get('TMPDIR') or '/tmp',
         'QT_ENABLE_EMOJI': '0'
     }
-    
+
     # PyInstaller-specific: Add Qt plugin paths
     if getattr(sys, '_MEIPASS', None):
         bundle_dir = sys._MEIPASS
         qt_plugins = os.path.join(bundle_dir, 'PyQt6', 'Qt6', 'plugins')
         if os.path.exists(qt_plugins):
             minimal_env['QT_PLUGIN_PATH'] = qt_plugins
-        
+
         platform_plugins = os.path.join(bundle_dir, 'PyQt6', 'Qt6', 'plugins', 'platforms')
         if os.path.exists(platform_plugins):
             minimal_env['QT_QPA_PLATFORM_PLUGIN_PATH'] = platform_plugins
-    
+
     # Clear all environment variables
     os.environ.clear()
-    
+
     # Set the minimal required ones
     for key, value in minimal_env.items():
         if value:
             os.environ[key] = value
 
-    
+
 
 from gui import AlignmentGUI
 from PyQt6.QtWidgets import QApplication
-from voxkit.storage.utils import get_storage_root
+from voxkit.config import STARTUP_SCRIPT
+from voxkit.gui.workers.startup import execute_startup_script
 
 
 def main():
-    # Ensure required directories exist in storage root
-    try:
-        storage_root = get_storage_root()
-        print(f"[INFO] Storage root: {storage_root}")
-        
-        (storage_root / "computed-likelihoods").mkdir(parents=True, exist_ok=True)
-        (storage_root / "custom-likelihoods").mkdir(parents=True, exist_ok=True)
-        print("[INFO] Created required directories")
-    except Exception as e:
-        print(f"[WARNING] Could not create directories: {e}")
-        # Continue anyway - directories will be created on-demand if needed
-    
     app = QApplication(sys.argv)
     app.setStyle("Fusion")
+
+    # Execute startup script on first launch (before GUI initialization)
+    execute_startup_script(STARTUP_SCRIPT, app)
+
     window = AlignmentGUI()
     window.show()
     sys.exit(app.exec())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ exclude = [
     "__pycache__",
     "main.py",
     "build.py",
+    "example_startup_script.py",
+    "test_imports.py",
 ]
 
 [tool.ruff.lint]
@@ -98,7 +100,9 @@ python_version = "3.11"
 ignore_missing_imports = true
 exclude = [
     "main.py",
-    "build.py"
+    "build.py",
+    "example_startup_script.py",
+    "test_imports.py"
 ]
 
 [tool.setuptools.packages.find]

--- a/src/voxkit/config.py
+++ b/src/voxkit/config.py
@@ -1,7 +1,11 @@
 import time
 from typing import Callable, Literal
 
+from voxkit.storage.config import MODELS_ROOT
 from voxkit.storage.utils import get_storage_root
+from voxkit.storage import models
+from voxkit.services.hf import download_and_copy_huggingface_model
+from voxkit.services.mfa import download_acoustic_model
 
 AppName = "VoxKit"
 Dimensions = {"min_width": 200, "min_height": 800, "max_width": 500, "max_height": None}
@@ -29,6 +33,61 @@ def startup_routine():
     (storage_root / "computed-likelihoods").mkdir(parents=True, exist_ok=True)
     (storage_root / "custom-likelihoods").mkdir(parents=True, exist_ok=True)
     time.sleep(1)  # Simulate directory setup
+
+    # Download MFA models
+    print("[STARTUP] Downloading MFA models...")
+    mfa_models = ["acoustic-english_us_arpa-v3.0.0/english_us_arpa.zip", "acoustic-spanish_mfa-v3.3.0/spanish_mfa.zip"]
+    mfa_models_path = storage_root / "MFAENGINE" / MODELS_ROOT
+    mfa_models_path.mkdir(parents=True, exist_ok=True)
+    for model in mfa_models:
+        success, metadata = models.create_model('MFAENGINE', model.split('/')[1].replace('.zip', ''))
+        if not success:
+            print(f"[STARTUP] Failed to create model metadata for {model}. {metadata}")
+            continue
+        model_dest = metadata.get('model_path')
+        if not model_dest:
+            print(f"[STARTUP] Model path not found in metadata for {model}.")
+            continue
+
+        # Remove last part of path and relace with .zip
+        output_file = model_dest.parent / model.split('/')[1]
+
+        try:
+            download_acoustic_model(model, str(output_file))
+            # Update metadata to reflect downloaded file
+            print(f"[STARTUP] MFA model {model} downloaded to: {output_file}")
+            success, message = models.update_model_metadata('MFAENGINE', metadata['id'], {'model_path': str(output_file)})
+
+            if not success:
+                print(f"[STARTUP] Failed to update model metadata for {model}. {message}")
+
+            print(f"[STARTUP] MFA model downloaded to: {output_file}")
+        except Exception as e:
+            print(f"[STARTUP] Failed to download MFA model {model}. Error: {e}")
+    
+    # Download W2TG model from HuggingFace
+    print("[STARTUP] Downloading W2TG model from HuggingFace...")
+    # Create folder for W2TG model
+    w2tg_path = storage_root / "W2TGENGINE" / MODELS_ROOT
+    w2tg_path.mkdir(parents=True, exist_ok=True)
+    success, metadata = models.create_model('W2TGENGINE', 'prads_model')
+    if not success:
+        print(f"[STARTUP] Failed to create model metadata. {metadata}")
+        return
+    model_dest = metadata.get('model_path')
+    if not model_dest:
+        print("[STARTUP] Model path not found in metadata.")
+        return
+    result = download_and_copy_huggingface_model(
+        model_path="pkadambi/Wav2TextGrid",
+        destination=str(model_dest),
+    )
+    if result:
+        print(f"[STARTUP] W2TG model downloaded to: {result}")
+    else:
+        print("[STARTUP] Failed to download W2TG model.")
+
+
 
     print("[STARTUP] Initialization complete!")
 

--- a/src/voxkit/config.py
+++ b/src/voxkit/config.py
@@ -1,4 +1,7 @@
-from typing import Literal
+import time
+from typing import Callable, Literal
+
+from voxkit.storage.utils import get_storage_root
 
 AppName = "VoxKit"
 Dimensions = {"min_width": 200, "min_height": 800, "max_width": 500, "max_height": None}
@@ -12,3 +15,24 @@ Defaults = {
 
 Mode = Literal["MFAENGINE", "W2TGENGINE"]
 HELP_URL = "http://localhost:3000/help"
+
+
+def startup_routine():
+    """Example startup routine to be executed on first launch."""
+    print("[STARTUP] Initializing VoxKit...")
+    time.sleep(1)  # Simulate initialization
+
+    storage_root = get_storage_root()
+    print(f"[STARTUP] Storage root: {storage_root}")
+
+    print("[STARTUP] Creating required directories...")
+    (storage_root / "computed-likelihoods").mkdir(parents=True, exist_ok=True)
+    (storage_root / "custom-likelihoods").mkdir(parents=True, exist_ok=True)
+    time.sleep(1)  # Simulate directory setup
+
+    print("[STARTUP] Initialization complete!")
+
+
+# Startup script configuration
+# Set this to a callable function to run on first launch, or None to disable
+STARTUP_SCRIPT: Callable[[], None] | None = startup_routine

--- a/src/voxkit/engines/base.py
+++ b/src/voxkit/engines/base.py
@@ -145,6 +145,7 @@ class AlignmentEngine(ABC):
         """
         if isinstance(path, str):
             path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=4)
 
@@ -171,6 +172,18 @@ class AlignmentEngine(ABC):
         with open(path, "r", encoding="utf-8") as f:
             return json.load(f)
 
+    def _get_default_settings(self, cfg: SettingsConfig) -> dict:
+        """
+        Extract default values from SettingsConfig fields.
+
+        Args:
+            cfg: The SettingsConfig object containing field definitions.
+
+        Returns:
+            Dictionary mapping field names to their default values.
+        """
+        return {field.name: field.default_value for field in (cfg.fields or [])}
+
     def get_settings(self, tool_type: ToolType) -> dict:
         """
         Load and validate settings for a specific tool.
@@ -178,7 +191,9 @@ class AlignmentEngine(ABC):
         This method reads the JSON settings file defined by the engine's
         ``settings_configurations`` for the given ``tool_type``, validates the
         settings using the engine-provided validator, and returns the parsed
-        settings dictionary.
+        settings dictionary. If the settings file doesn't exist, it falls back
+        to default values extracted from the SettingsConfig fields and saves
+        them to disk for future use.
 
         Args:
             tool_type: The tool type to retrieve settings for ("train" or
@@ -197,24 +212,27 @@ class AlignmentEngine(ABC):
 
         cfg = self.settings_configurations[tool_type]
         if not cfg.store_file:
-            raise FileNotFoundError(
-                f"Settings path not given for tool type '{tool_type}' in this engine."
-            )
-        settings = self._load_json(Path(get_storage_root() / cfg.store_file))
+            raise ValueError(f"Settings path not configured for tool type '{tool_type}'.")
 
-        if tool_type == "train":
-            if settings is None:
-                # Get default settings if none exist
-                settings = cfg.default_settings or {}
-            if not self._validate_train_settings(settings):
-                raise ValueError(f"Invalid training settings: {settings}")
-            return settings
-        elif tool_type == "align":
-            if not self._validate_align_settings(settings):
-                raise ValueError(f"Invalid alignment settings: {settings}")
-            return settings
-        else:
-            raise ValueError(f"Invalid tool_type: {tool_type}.")
+        settings_path = Path(get_storage_root() / cfg.store_file)
+        settings = self._load_json(settings_path)
+
+        # Fallback to defaults if file doesn't exist or is empty
+        if not settings:
+            settings = self._get_default_settings(cfg)
+            self._save_json(settings, settings_path)
+
+        # Validate settings
+        is_valid = (
+            self._validate_train_settings(settings)
+            if tool_type == "train"
+            else self._validate_align_settings(settings)
+        )
+
+        if not is_valid:
+            raise ValueError(f"Invalid {tool_type} settings: {settings}")
+
+        return settings
 
     def get_settings_config(self, tool_type: ToolType) -> SettingsConfig:
         """

--- a/src/voxkit/engines/test_base.py
+++ b/src/voxkit/engines/test_base.py
@@ -1,0 +1,208 @@
+"""Test suite for AlignmentEngine base functionality."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from voxkit.engines.base import AlignmentEngine, ToolType
+from voxkit.gui.frameworks.settings_modal import FieldConfig, FieldType, SettingsConfig
+
+
+class MockEngine(AlignmentEngine):
+    """Mock implementation of AlignmentEngine for testing."""
+
+    def align(self, dataset_id: str, model_id: str) -> None:
+        """Mock align method."""
+        pass
+
+    def train_aligner(
+        self, audio_root: Path, textgrid_root: Path, base_model_id: str | None, new_model_id: str
+    ) -> None:
+        """Mock train_aligner method."""
+        pass
+
+    def _validate_train_settings(self, settings: dict) -> bool:
+        """Validate training settings."""
+        required_keys = ["epochs", "use_gpu"]
+        return all(key in settings for key in required_keys)
+
+    def _validate_align_settings(self, settings: dict) -> bool:
+        """Validate alignment settings."""
+        required_keys = ["use_speaker_adaptation", "file_type"]
+        return all(key in settings for key in required_keys)
+
+
+@pytest.fixture
+def temp_storage_root(tmp_path):
+    """Provide a temporary storage root directory."""
+    return tmp_path
+
+
+@pytest.fixture
+def mock_engine():
+    """Create a mock engine with test configurations."""
+    train_config = SettingsConfig(
+        title="Test Training Settings",
+        dimensions=(400, 300),
+        apply_blur=True,
+        fields=[
+            FieldConfig(
+                name="epochs",
+                label="Number of Epochs",
+                field_type=FieldType.SPINBOX,
+                default_value=50,
+                min_value=1,
+                max_value=1000,
+            ),
+            FieldConfig(
+                name="use_gpu",
+                label="Use GPU",
+                field_type=FieldType.CHECKBOX,
+                default_value=False,
+            ),
+        ],
+        store_file="TEST_ENGINE/train/settings.json",
+    )
+
+    align_config = SettingsConfig(
+        title="Test Alignment Settings",
+        dimensions=(400, 300),
+        apply_blur=True,
+        fields=[
+            FieldConfig(
+                name="use_speaker_adaptation",
+                label="Use Speaker Adaptation",
+                field_type=FieldType.CHECKBOX,
+                default_value=False,
+            ),
+            FieldConfig(
+                name="file_type",
+                label="File Type",
+                field_type=FieldType.LINEEDIT,
+                default_value="wav",
+            ),
+        ],
+        store_file="TEST_ENGINE/align/settings.json",
+    )
+
+    return MockEngine(
+        settings_configurations={"train": train_config, "align": align_config},
+        id="TEST_ENGINE",
+    )
+
+
+class TestGetDefaultSettings:
+    """Test the _get_default_settings method."""
+
+    def test_extracts_defaults_from_config(self, mock_engine):
+        """Test that default settings are correctly extracted from SettingsConfig."""
+        train_config = mock_engine.settings_configurations["train"]
+        defaults = mock_engine._get_default_settings(train_config)
+
+        assert defaults == {"epochs": 50, "use_gpu": False}
+
+    def test_handles_empty_fields(self, mock_engine):
+        """Test handling of SettingsConfig with no fields."""
+        empty_config = SettingsConfig(
+            title="Empty Config",
+            dimensions=(400, 300),
+            apply_blur=False,
+            fields=[],
+            store_file="empty.json",
+        )
+        defaults = mock_engine._get_default_settings(empty_config)
+        assert defaults == {}
+
+
+class TestGetSettings:
+    """Test the get_settings method with default fallback behavior."""
+
+    def test_returns_defaults_when_file_missing(self, mock_engine, temp_storage_root):
+        """Test that default settings are returned when JSON file doesn't exist."""
+        with patch("voxkit.engines.base.get_storage_root", return_value=temp_storage_root):
+            settings = mock_engine.get_settings("align")
+
+            # Should return the default values
+            assert settings == {"use_speaker_adaptation": False, "file_type": "wav"}
+
+            # Should have created the settings file
+            settings_path = temp_storage_root / "TEST_ENGINE/align/settings.json"
+            assert settings_path.exists()
+
+            # Verify the saved file contains the defaults
+            with open(settings_path) as f:
+                saved_settings = json.load(f)
+            assert saved_settings == settings
+
+    def test_loads_existing_settings(self, mock_engine, temp_storage_root):
+        """Test that existing settings are loaded when file exists."""
+        # Create settings file with custom values
+        settings_path = temp_storage_root / "TEST_ENGINE/train/settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        custom_settings = {"epochs": 100, "use_gpu": True}
+        with open(settings_path, "w") as f:
+            json.dump(custom_settings, f)
+
+        with patch("voxkit.engines.base.get_storage_root", return_value=temp_storage_root):
+            settings = mock_engine.get_settings("train")
+            assert settings == custom_settings
+
+    def test_validates_loaded_settings(self, mock_engine, temp_storage_root):
+        """Test that loaded settings are validated."""
+        # Create settings file with invalid values
+        settings_path = temp_storage_root / "TEST_ENGINE/align/settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        invalid_settings = {"invalid_key": "value"}
+        with open(settings_path, "w") as f:
+            json.dump(invalid_settings, f)
+
+        with patch("voxkit.engines.base.get_storage_root", return_value=temp_storage_root):
+            with pytest.raises(ValueError, match="Invalid align settings"):
+                mock_engine.get_settings("align")
+
+    def test_validates_default_settings(self, mock_engine, temp_storage_root):
+        """Test that default settings pass validation."""
+        with patch("voxkit.engines.base.get_storage_root", return_value=temp_storage_root):
+            # Should not raise an error
+            settings = mock_engine.get_settings("train")
+            assert settings is not None
+
+    def test_raises_error_for_unavailable_tool(self, mock_engine):
+        """Test that error is raised for unavailable tool type."""
+        with pytest.raises(ValueError, match="Tool type 'invalid' is not available"):
+            mock_engine.get_settings("invalid")
+
+    def test_unified_behavior_train_and_align(self, mock_engine, temp_storage_root):
+        """Test that train and align tool types behave consistently."""
+        with patch("voxkit.engines.base.get_storage_root", return_value=temp_storage_root):
+            # Both should work without errors and create default settings
+            train_settings = mock_engine.get_settings("train")
+            align_settings = mock_engine.get_settings("align")
+
+            assert train_settings is not None
+            assert align_settings is not None
+
+            # Both should have created files
+            train_path = temp_storage_root / "TEST_ENGINE/train/settings.json"
+            align_path = temp_storage_root / "TEST_ENGINE/align/settings.json"
+            assert train_path.exists()
+            assert align_path.exists()
+
+
+class TestSaveJson:
+    """Test the _save_json method."""
+
+    def test_creates_parent_directories(self, mock_engine, temp_storage_root):
+        """Test that parent directories are created if they don't exist."""
+        test_path = temp_storage_root / "deep/nested/path/test.json"
+        test_data = {"key": "value"}
+
+        mock_engine._save_json(test_data, test_path)
+
+        assert test_path.exists()
+        with open(test_path) as f:
+            loaded_data = json.load(f)
+        assert loaded_data == test_data

--- a/src/voxkit/gui/components/__init__.py
+++ b/src/voxkit/gui/components/__init__.py
@@ -4,6 +4,7 @@ from .csv_visual import CSVVisualizationWidget
 from .dna_strand import DNAStrandWidget
 from .horizontal_button_selector import HorizontalButtonSelector
 from .huggingface_button import HuggingFaceButton, HuggingFaceIconButton
+from .loading_dialog import LoadingDialog
 from .overlay_effects import OverlayWidget
 from .toggle_switch import ToggleSwitch
 
@@ -13,6 +14,7 @@ __all__ = [
     "DNAStrandWidget",
     "HuggingFaceButton",
     "HuggingFaceIconButton",
+    "LoadingDialog",
     "MultiColumnComboBox",
     "OverlayWidget",
     "ToggleSwitch",

--- a/src/voxkit/gui/components/loading_dialog.py
+++ b/src/voxkit/gui/components/loading_dialog.py
@@ -1,0 +1,152 @@
+"""Loading Dialog Component.
+
+This module provides a splash screen/loading dialog for displaying progress
+during long-running operations like first-launch startup scripts.
+"""
+
+from PyQt6.QtCore import QEasingCurve, QPropertyAnimation, Qt, QTimer
+from PyQt6.QtWidgets import QDialog, QGraphicsOpacityEffect, QLabel, QVBoxLayout
+
+
+class LoadingDialog(QDialog):
+    """A modal loading dialog with a message and spinner.
+
+    This dialog is used to display a loading message while a long-running
+    operation is in progress. It blocks user interaction with the main
+    application until the operation completes.
+
+    Args:
+        message: The message to display in the dialog
+        parent: Optional parent widget
+    """
+
+    def __init__(self, message: str = "Loading...", parent=None):
+        super().__init__(parent)
+        self.setModal(True)
+        self.setWindowFlags(
+            Qt.WindowType.Dialog
+            | Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.WindowStaysOnTopHint
+        )
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+
+        # Animation state
+        self._spinner_index = 0
+        self._spinner_frames = ["◐", "◓", "◑", "◒"]
+
+        self.init_ui(message)
+
+        # Center the dialog on screen
+        self.center_on_screen()
+
+        # Setup fade-in animation
+        self.opacity_effect = QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity_effect)
+        self.fade_in_animation = QPropertyAnimation(self.opacity_effect, b"opacity")
+        self.fade_in_animation.setDuration(300)
+        self.fade_in_animation.setStartValue(0.0)
+        self.fade_in_animation.setEndValue(1.0)
+        self.fade_in_animation.setEasingCurve(QEasingCurve.Type.InOutQuad)
+
+        # Setup spinner animation timer
+        self.spinner_timer = QTimer(self)
+        self.spinner_timer.timeout.connect(self._update_spinner)
+        self.spinner_timer.start(150)  # Update every 150ms
+
+    def init_ui(self, message: str):
+        """Initialize the dialog UI."""
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(40, 40, 40, 40)
+        layout.setSpacing(20)
+
+        # Message label
+        message_label = QLabel(message)
+        message_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        message_label.setStyleSheet(
+            """
+            QLabel {
+                color: #2c3e50;
+                font-size: 16px;
+                font-weight: bold;
+                background-color: #ffffff;
+                padding: 20px;
+                border-radius: 10px;
+                border: 2px solid #3498db;
+            }
+            """
+        )
+        layout.addWidget(message_label)
+
+        # Progress indicator label (animated spinner)
+        self.progress_label = QLabel(self._spinner_frames[0])
+        self.progress_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.progress_label.setStyleSheet(
+            """
+            QLabel {
+                color: #3498db;
+                font-size: 32px;
+                background-color: #ffffff;
+                padding: 10px;
+                border-radius: 10px;
+                font-weight: bold;
+            }
+            """
+        )
+        layout.addWidget(self.progress_label)
+
+        # Set dialog background with shadow effect
+        self.setStyleSheet(
+            """
+            QDialog {
+                background-color: rgba(255, 255, 255, 250);
+                border-radius: 15px;
+                border: 3px solid #3498db;
+            }
+            """
+        )
+
+        self.setFixedSize(400, 250)
+
+    def center_on_screen(self):
+        """Center the dialog on the primary screen."""
+        from PyQt6.QtGui import QGuiApplication
+
+        screen = QGuiApplication.primaryScreen().geometry()
+        dialog_rect = self.frameGeometry()
+        center_point = screen.center()
+        dialog_rect.moveCenter(center_point)
+        self.move(dialog_rect.topLeft())
+
+    def _update_spinner(self):
+        """Update the spinner animation."""
+        self._spinner_index = (self._spinner_index + 1) % len(self._spinner_frames)
+        self.progress_label.setText(self._spinner_frames[self._spinner_index])
+
+    def showEvent(self, event):
+        """Override show event to trigger fade-in animation."""
+        super().showEvent(event)
+        self.fade_in_animation.start()
+
+    def update_message(self, message: str):
+        """Update the message displayed in the dialog.
+
+        Args:
+            message: The new message to display
+        """
+        if self.layout() and self.layout().itemAt(0):
+            label = self.layout().itemAt(0).widget()
+            if isinstance(label, QLabel):
+                label.setText(message)
+
+    def close_gracefully(self):
+        """Close the dialog with a fade-out animation."""
+        self.spinner_timer.stop()
+        fade_out = QPropertyAnimation(self.opacity_effect, b"opacity")
+        fade_out.setDuration(200)
+        fade_out.setStartValue(1.0)
+        fade_out.setEndValue(0.0)
+        fade_out.setEasingCurve(QEasingCurve.Type.InOutQuad)
+        fade_out.finished.connect(self.accept)
+        fade_out.start()
+        # Keep reference to prevent garbage collection
+        self._fade_out = fade_out

--- a/src/voxkit/gui/workers/startup.py
+++ b/src/voxkit/gui/workers/startup.py
@@ -1,0 +1,106 @@
+"""Startup Script Module.
+
+This module handles the execution of startup scripts that run on the first
+launch of the application. It provides a mechanism to execute a Python
+function before the GUI is fully initialized.
+
+API
+---
+- **execute_startup_script**: Execute the configured startup script if applicable
+"""
+
+from typing import Callable
+
+from PyQt6.QtCore import QThread, pyqtSignal
+from PyQt6.QtWidgets import QApplication
+
+from voxkit.gui.components import LoadingDialog
+from voxkit.storage.utils import is_first_launch, mark_first_launch_complete
+
+
+class StartupScriptWorker(QThread):
+    """Worker thread for executing the startup script without blocking the UI.
+
+    Signals:
+        finished: Emitted when the script execution is complete
+        error: Emitted when an error occurs during script execution
+    """
+
+    finished = pyqtSignal()
+    error = pyqtSignal(str)
+
+    def __init__(self, script: Callable[[], None]):
+        super().__init__()
+        self.script = script
+
+    def run(self):
+        """Execute the startup script."""
+        try:
+            self.script()
+            self.finished.emit()
+        except Exception as e:
+            self.error.emit(str(e))
+
+
+def execute_startup_script(script: Callable[[], None] | None, app: QApplication) -> None:
+    """Execute the startup script if this is the first launch.
+
+    This function checks if this is the first launch of the application. If it is,
+    it executes the provided startup script while displaying a loading dialog.
+    After successful execution, it marks the first launch as complete.
+
+    Args:
+        script: The startup script function to execute, or None to skip
+        app: The QApplication instance for event processing
+
+    Note:
+        This function blocks until the script execution is complete.
+    """
+    if script is None:
+        return
+
+    if not is_first_launch():
+        return
+
+    # Create and show the loading dialog
+    loading_dialog = LoadingDialog("Retrieving assets...")
+    loading_dialog.show()
+
+    # Process events multiple times to ensure the dialog is fully rendered
+    for _ in range(3):
+        app.processEvents()
+
+    # Give the dialog time to render before starting work
+    from PyQt6.QtCore import QTimer
+
+    QTimer.singleShot(100, lambda: None)
+    app.processEvents()
+
+    # Create and start the worker thread
+    worker = StartupScriptWorker(script)
+
+    # Connect signals
+    def on_finished():
+        mark_first_launch_complete()
+        loading_dialog.update_message("Complete!")
+        app.processEvents()
+        loading_dialog.close_gracefully()
+
+    def on_error(error_msg: str):
+        print(f"[ERROR] Startup script failed: {error_msg}")
+        loading_dialog.update_message(f"Error: {error_msg}")
+        app.processEvents()
+        # Still mark as complete to avoid running again
+        mark_first_launch_complete()
+        # Wait a bit to show error before closing
+        from PyQt6.QtCore import QTimer
+
+        QTimer.singleShot(2000, loading_dialog.close_gracefully)
+
+    worker.finished.connect(on_finished)
+    worker.error.connect(on_error)
+
+    # Start the worker and wait for completion
+    worker.start()
+    loading_dialog.exec()
+    worker.wait()

--- a/src/voxkit/services/mfa.py
+++ b/src/voxkit/services/mfa.py
@@ -101,13 +101,28 @@ def run_mfa_adapt(
         raise
 
 
-if __name__ == "__main__":
-    # Example usage
-    corpus_directory = "/Users/beckettfrey/Desktop/audio"
-    model_file_path = (
-        "/Users/beckettfrey/.voxkit/MFAENGINE/train/20260106_100909_114224/entrypoint.zip"
-    )
-    output_directory = "."
-    evaluation_directory = None
+def download_acoustic_model(release_path, output_file):
+    """
+    Download an MFA acoustic model using the github releases ai  for example release_path = acoustic-spanish_mfa-v3.3.0/spanish_mfa.zip becomes url "https://github.com/MontrealCorpusTools/mfa-models/releases/download/acoustic-spanish_mfa-v3.3.0/spanish_mfa.zip"
+    """
+    url = f"https://github.com/MontrealCorpusTools/mfa-models/releases/download/{release_path}"
+    cmd = ["curl", "-L", "-o", output_file, url]
+    try:
+        print(f"[mfa.download_acoustic_model] Downloading model from {url} to {output_file}")
+        subprocess.run(cmd, check=True)
+        print("[mfa.download_acoustic_model] Model downloaded successfully.")
+    except subprocess.CalledProcessError as e:
+        print(f"[mfa.download_acoustic_model] Model download failed with error: {e}")
+        raise
 
-    run_mfa_align(corpus_directory, model_file_path, output_directory, evaluation_directory)
+if __name__ == "__main__":
+    # Example model download
+    download_acoustic_model(
+        "acoustic-spanish_mfa-v3.3.0/spanish_mfa.zip",
+        "spanish_mfa.zip",
+    )
+    download_acoustic_model(
+        "acoustic-english_us_arpa-v3.0.0/english_us_arpa.zip",
+        "english_us_arpa.zip",
+    )
+   

--- a/src/voxkit/storage/test/test_startup.py
+++ b/src/voxkit/storage/test/test_startup.py
@@ -1,0 +1,82 @@
+"""Tests for startup script functionality."""
+
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ..utils import is_first_launch, mark_first_launch_complete
+
+
+@pytest.fixture
+def temp_storage_root(tmp_path):
+    """Create a temporary storage root for testing."""
+    storage_root = tmp_path / ".voxkit"
+    storage_root.mkdir(parents=True, exist_ok=True)
+    
+    # Patch get_storage_root to return our temp directory
+    with patch("voxkit.storage.utils.get_storage_root", return_value=storage_root):
+        yield storage_root
+    
+    # Cleanup
+    if storage_root.exists():
+        shutil.rmtree(storage_root)
+
+
+def test_is_first_launch_when_no_flag_exists(temp_storage_root):
+    """Test that is_first_launch returns True when flag file doesn't exist."""
+    # Patch get_storage_root for the functions being tested
+    with patch("voxkit.storage.utils.get_storage_root", return_value=temp_storage_root):
+        assert is_first_launch() is True
+
+
+def test_is_first_launch_when_flag_exists(temp_storage_root):
+    """Test that is_first_launch returns False when flag file exists."""
+    flag_file = temp_storage_root / ".first_launch_complete"
+    flag_file.touch()
+    
+    with patch("voxkit.storage.utils.get_storage_root", return_value=temp_storage_root):
+        assert is_first_launch() is False
+
+
+def test_mark_first_launch_complete(temp_storage_root):
+    """Test that mark_first_launch_complete creates the flag file."""
+    with patch("voxkit.storage.utils.get_storage_root", return_value=temp_storage_root):
+        mark_first_launch_complete()
+        
+        flag_file = temp_storage_root / ".first_launch_complete"
+        assert flag_file.exists()
+
+
+def test_mark_first_launch_complete_creates_storage_root(tmp_path):
+    """Test that mark_first_launch_complete creates storage root if it doesn't exist."""
+    storage_root = tmp_path / ".voxkit_test"
+    
+    with patch("voxkit.storage.utils.get_storage_root", return_value=storage_root):
+        mark_first_launch_complete()
+        
+        assert storage_root.exists()
+        flag_file = storage_root / ".first_launch_complete"
+        assert flag_file.exists()
+    
+    # Cleanup
+    if storage_root.exists():
+        shutil.rmtree(storage_root)
+
+
+def test_first_launch_workflow(temp_storage_root):
+    """Test the complete workflow of first launch detection and marking."""
+    with patch("voxkit.storage.utils.get_storage_root", return_value=temp_storage_root):
+        # Initially should be first launch
+        assert is_first_launch() is True
+        
+        # Mark as complete
+        mark_first_launch_complete()
+        
+        # Should no longer be first launch
+        assert is_first_launch() is False
+        
+        # Marking again should be idempotent
+        mark_first_launch_complete()
+        assert is_first_launch() is False

--- a/src/voxkit/storage/utils.py
+++ b/src/voxkit/storage/utils.py
@@ -8,12 +8,15 @@ API
 - **get_storage_root**: Get the root directory for storing VoxKit data
 - **generate_unique_id**: Generate a unique identifier with timestamp
 - **readable_from_unique_id**: Convert a unique ID to human-readable format
+- **is_first_launch**: Check if this is the first launch of the application
+- **mark_first_launch_complete**: Mark the first launch as complete
 
 Notes
 -----
 - The storage root uses tilde (~) notation to ensure it references the user's home directory
 - Unique IDs are based on timestamps with microsecond precision (YYYYMMDD_HHMMSS_ffffff)
 - The storage root path is cached for performance using lru_cache
+- First launch tracking uses a flag file (.first_launch_complete) in the storage root
 """
 
 from datetime import datetime
@@ -65,3 +68,22 @@ def readable_from_unique_id(date_str: str) -> str:
     """
     dt = datetime.strptime(date_str, "%Y%m%d_%H%M%S_%f")
     return dt.strftime("%B %d, %Y at %I:%M:%S %p")
+
+
+def is_first_launch() -> bool:
+    """Check if this is the first launch of the application.
+
+    Returns:
+        True if this is the first launch, False otherwise
+    """
+    storage_root = get_storage_root()
+    flag_file = storage_root / ".first_launch_complete"
+    return not flag_file.exists()
+
+
+def mark_first_launch_complete() -> None:
+    """Mark the first launch as complete by creating a flag file."""
+    storage_root = get_storage_root()
+    storage_root.mkdir(parents=True, exist_ok=True)
+    flag_file = storage_root / ".first_launch_complete"
+    flag_file.touch()


### PR DESCRIPTION
This fixes #35 by simply removing os.environ.clear() from the runtime routine to maintain the needed PATH for conda discovery and other conda specific environment variables.