### PR TITLE
VOX-75

### DIFF
--- a/hooks/hook-nltk.py
+++ b/hooks/hook-nltk.py
@@ -1,0 +1,11 @@
+"""PyInstaller hook for nltk package.
+
+This hook prevents PyInstaller from collecting NLTK data files.
+NLTK data is downloaded at runtime by the application instead.
+"""
+
+# Don't collect any NLTK data files - they will be downloaded at runtime
+datas = []
+
+# Exclude data collection
+excludedimports = []

--- a/src/voxkit/config.py
+++ b/src/voxkit/config.py
@@ -72,27 +72,35 @@ def startup_routine():
         except Exception as e:
             print(f"[STARTUP] Failed to download MFA model {model}. Error: {e}")
 
-    # Download W2TG model from HuggingFace
-    print("[STARTUP] Downloading W2TG model from HuggingFace...")
-    # Create folder for W2TG model
-    w2tg_path = storage_root / "W2TGENGINE" / MODELS_ROOT
-    w2tg_path.mkdir(parents=True, exist_ok=True)
-    success, metadata = models.create_model("W2TGENGINE", "prads_model")
-    if not success:
-        print(f"[STARTUP] Failed to create model metadata. {metadata}")
-        return
-    model_dest = metadata.get("model_path")
-    if not model_dest:
-        print("[STARTUP] Model path not found in metadata.")
-        return
-    result = download_and_copy_huggingface_model(
-        model_path="pkadambi/Wav2TextGrid",
-        destination=str(model_dest),
-    )
-    if result:
-        print(f"[STARTUP] W2TG model downloaded to: {result}")
-    else:
-        print("[STARTUP] Failed to download W2TG model.")
+    # # Download W2TG model from HuggingFace
+    # print("[STARTUP] Downloading W2TG model from HuggingFace...")
+    # # Create folder for W2TG model
+    # w2tg_path = storage_root / "W2TGENGINE" / MODELS_ROOT
+    # w2tg_path.mkdir(parents=True, exist_ok=True)
+    # success, metadata = models.create_model("W2TGENGINE", "prads_model")
+    # if not success:
+    #     print(f"[STARTUP] Failed to create model metadata. {metadata}")
+    #     return
+    # model_dest = metadata.get("model_path")
+    # if not model_dest:
+    #     print("[STARTUP] Model path not found in metadata.")
+    #     return
+    # result = download_and_copy_huggingface_model(
+    #     model_path="pkadambi/Wav2TextGrid",
+    #     destination=str(model_dest),
+    # )
+    # if result:
+    #     print(f"[STARTUP] W2TG model downloaded to: {result}")
+    # else:
+    #     print("[STARTUP] Failed to download W2TG model.")
+
+
+    try:
+        import nltk
+        nltk.download('averaged_perceptron_tagger_eng')
+
+    except Exception as e:
+        print(f"[STARTUP] Failed to download NLTK resources. Error: {e}")
 
     print("[STARTUP] Initialization complete!")
 

--- a/src/voxkit/config/startup_config.py
+++ b/src/voxkit/config/startup_config.py
@@ -18,7 +18,7 @@ Defaults = {
 }
 
 Mode = Literal["MFAENGINE", "W2TGENGINE"]
-HELP_URL = "http://localhost:3000/help"
+HELP_URL = "https://voxkit-web.vercel.app/help"
 
 
 def startup_routine():
@@ -72,27 +72,35 @@ def startup_routine():
         except Exception as e:
             print(f"[STARTUP] Failed to download MFA model {model}. Error: {e}")
 
-    # Download W2TG model from HuggingFace
-    print("[STARTUP] Downloading W2TG model from HuggingFace...")
-    # Create folder for W2TG model
-    w2tg_path = storage_root / "W2TGENGINE" / MODELS_ROOT
-    w2tg_path.mkdir(parents=True, exist_ok=True)
-    success, metadata = models.create_model("W2TGENGINE", "prads_model")
-    if not success:
-        print(f"[STARTUP] Failed to create model metadata. {metadata}")
-        return
-    model_dest = metadata.get("model_path")
-    if not model_dest:
-        print("[STARTUP] Model path not found in metadata.")
-        return
-    result = download_and_copy_huggingface_model(
-        model_path="pkadambi/Wav2TextGrid",
-        destination=str(model_dest),
-    )
-    if result:
-        print(f"[STARTUP] W2TG model downloaded to: {result}")
-    else:
-        print("[STARTUP] Failed to download W2TG model.")
+    # # Download W2TG model from HuggingFace
+    # print("[STARTUP] Downloading W2TG model from HuggingFace...")
+    # # Create folder for W2TG model
+    # w2tg_path = storage_root / "W2TGENGINE" / MODELS_ROOT
+    # w2tg_path.mkdir(parents=True, exist_ok=True)
+    # success, metadata = models.create_model("W2TGENGINE", "prads_model")
+    # if not success:
+    #     print(f"[STARTUP] Failed to create model metadata. {metadata}")
+    #     return
+    # model_dest = metadata.get("model_path")
+    # if not model_dest:
+    #     print("[STARTUP] Model path not found in metadata.")
+    #     return
+    # result = download_and_copy_huggingface_model(
+    #     model_path="pkadambi/Wav2TextGrid",
+    #     destination=str(model_dest),
+    # )
+    # if result:
+    #     print(f"[STARTUP] W2TG model downloaded to: {result}")
+    # else:
+    #     print("[STARTUP] Failed to download W2TG model.")
+
+
+    try:
+        import nltk
+        nltk.download('averaged_perceptron_tagger_eng')
+
+    except Exception as e:
+        print(f"[STARTUP] Failed to download NLTK resources. Error: {e}")
 
     print("[STARTUP] Initialization complete!")
 

--- a/src/voxkit/engines/__init__.py
+++ b/src/voxkit/engines/__init__.py
@@ -38,7 +38,7 @@ from typing import List
 from .base import AlignmentEngine, ToolType
 from .faster_whisper_engine import FasterWhisperEngine
 from .mfa_engine import MFAEngine
-from .w2tg_engine import W2TGEngine
+# from .w2tg_engine import W2TGEngine
 
 
 class EngineManager:
@@ -79,14 +79,13 @@ class EngineManager:
 
 
 # Singleton instance for unified export/interface
-w2tg = W2TGEngine(id="W2TGENGINE")
+# w2tg = W2TGEngine(id="W2TGENGINE")
 mfa = MFAEngine(id="MFAENGINE")
 faster_whisper = FasterWhisperEngine(id="FASTERWHISPERENGINE")
-engines = EngineManager({w2tg.id: w2tg, mfa.id: mfa, faster_whisper.id: faster_whisper})
+engines = EngineManager({ mfa.id: mfa, faster_whisper.id: faster_whisper})
 
 __all__ = [
     "engines",
-    "W2TGEngine",
     "MFAEngine",
     "FasterWhisperEngine",
     "AlignmentEngine",

--- a/src/voxkit/engines/mfa_engine.py
+++ b/src/voxkit/engines/mfa_engine.py
@@ -11,7 +11,7 @@ Settings
 --------
 Stored at ``~/.voxkit/MFAENGINE/{tool}/settings.json``:
 
-- **align**: use_speaker_adaptation, file_type
+- **align**: dictionary, file_type
 - **train**: epochs, use_gpu
 
 Notes
@@ -44,15 +44,15 @@ class MFAEngine(AlignmentEngine):
             settings_configurations={
                 "align": SettingsConfig(
                     title="MFA Aligner Settings",
-                    dimensions=(400, 300),
+                    dimensions=(400, 350),
                     apply_blur=True,
                     fields=[
                         FieldConfig(
-                            name="use_speaker_adaptation",
-                            label="Use Speaker Adaptation",
-                            field_type=FieldType.CHECKBOX,
-                            default_value=False,
-                            tooltip="Enable speaker adaptation for better alignment results.",
+                            name="dictionary",
+                            label="Dictionary",
+                            field_type=FieldType.LINEEDIT,
+                            default_value="english_us_arpa",
+                            tooltip="MFA dictionary name (e.g., english_us_arpa, english_mfa).",
                         ),
                         FieldConfig(
                             name="file_type",
@@ -62,21 +62,28 @@ class MFAEngine(AlignmentEngine):
                             tooltip="Specify the audio file type (e.g., wav, flac).",
                         ),
                     ],
-                    store_file="MFAENGINE/aligner/aligner_settings.json",
+                    store_file="MFAENGINE/align/settings.json",
                 ),
                 "train": SettingsConfig(
                     title="MFA Trainer Settings",
-                    dimensions=(400, 300),
+                    dimensions=(400, 350),
                     apply_blur=True,
                     fields=[
                         FieldConfig(
-                            name="epochs",
-                            label="Number of Epochs",
+                            name="dictionary",
+                            label="Dictionary",
+                            field_type=FieldType.LINEEDIT,
+                            default_value="english_us_arpa",
+                            tooltip="MFA dictionary name (e.g., english_us_arpa, english_mfa).",
+                        ),
+                        FieldConfig(
+                            name="num_iterations",
+                            label="Number of Iterations",
                             field_type=FieldType.SPINBOX,
-                            default_value=50,
+                            default_value=1,
                             min_value=1,
-                            max_value=1000,
-                            tooltip="The number of epochs to train the model for.",
+                            max_value=100,
+                            tooltip="Number of adaptation iterations.",
                         ),
                         FieldConfig(
                             name="use_gpu",
@@ -86,7 +93,7 @@ class MFAEngine(AlignmentEngine):
                             tooltip="Enable GPU acceleration for faster training.",
                         ),
                     ],
-                    store_file="MFAENGINE/train/trainer_settings.json",
+                    store_file="MFAENGINE/train/settings.json",
                 ),
             },
             reference_url="https://montreal-forced-aligner.readthedocs.io/en/latest/",

--- a/src/voxkit/services/mfa.py
+++ b/src/voxkit/services/mfa.py
@@ -1,13 +1,73 @@
 import subprocess
 
 
-def run_mfa_align(corpus_dir, model_path, output_dir, eval_dir=None) -> None:
+def ensure_dictionary_downloaded(dictionary_name: str = "english_us_arpa") -> None:
+    """Ensure the specified MFA dictionary is downloaded.
+
+    Args:
+        dictionary_name: Name of the dictionary to download (default: "english_us_arpa").
+
+    Raises:
+        AssertionError: If dictionary download fails and dictionary is not available.
+    """
+    download_cmd = [
+        "conda",
+        "run",
+        "-n",
+        "aligner",
+        "mfa",
+        "model",
+        "download",
+        "dictionary",
+        dictionary_name,
+    ]
+
+    print(f"[mfa] Ensuring dictionary '{dictionary_name}' is downloaded...")
+    result = subprocess.run(download_cmd, capture_output=True, text=True)
+
+    # Check if dictionary is available (either just downloaded or already present)
+    # MFA returns success if already downloaded, or downloads successfully
+    if result.returncode != 0:
+        # Try to list dictionaries to check if it's already available
+        list_cmd = [
+            "conda",
+            "run",
+            "-n",
+            "aligner",
+            "mfa",
+            "model",
+            "list",
+            "dictionary",
+        ]
+        list_result = subprocess.run(list_cmd, capture_output=True, text=True)
+        assert dictionary_name in list_result.stdout, (
+            f"Dictionary '{dictionary_name}' is not available. "
+            f"Download failed with: {result.stderr}"
+        )
+        print(f"[mfa] Dictionary '{dictionary_name}' already available.")
+    else:
+        print(f"[mfa] Dictionary '{dictionary_name}' is ready.")
+
+
+def run_mfa_align(
+    corpus_dir, model_path, output_dir, dictionary_name="english_us_arpa", eval_dir=None
+) -> None:
     """
     Run MFA align command with the provided arguments.
 
     Args:
-        args (List[str]): List of command-line arguments for MFA align.
+        corpus_dir: Path to the corpus directory.
+        model_path: Path to the acoustic model.
+        output_dir: Path to output TextGrids.
+        dictionary_name: MFA dictionary name (default: "english_us_arpa").
+        eval_dir: Optional path to reference alignments for evaluation.
+
+    Raises:
+        AssertionError: If dictionary is not available.
+        subprocess.CalledProcessError: If MFA alignment fails.
     """
+    # Ensure dictionary is downloaded
+    ensure_dictionary_downloaded(dictionary_name)
 
     cmd = [
         "conda",
@@ -17,9 +77,10 @@ def run_mfa_align(corpus_dir, model_path, output_dir, eval_dir=None) -> None:
         "mfa",
         "align",
         corpus_dir,
-        "english_us_arpa",
+        dictionary_name,
         model_path,
         output_dir,
+        "--clean",  # Add clean flag to avoid cache issues
     ]
 
     if eval_dir:
@@ -51,28 +112,13 @@ def run_mfa_adapt(
         output_model_path (str): Path where the adapted model will be saved.
         dictionary_name (str): Name of the dictionary to use (default: "english_us_arpa").
         num_iterations (int): Number of adaptation iterations.
-    """
-    # First, ensure the dictionary is downloaded
-    download_cmd = [
-        "conda",
-        "run",
-        "-n",
-        "aligner",
-        "mfa",
-        "model",
-        "download",
-        "dictionary",
-        "english_us_arpa",
-    ]
 
-    try:
-        print("[mfa.run_mfa_adapt] Ensuring dictionary is downloaded...")
-        subprocess.run(download_cmd, check=True, capture_output=True, text=True)
-    except subprocess.CalledProcessError:
-        print(
-            "[mfa.run_mfa_adapt] Dictionary already downloaded or "
-            "download failed (continuing anyway)"
-        )
+    Raises:
+        AssertionError: If dictionary is not available.
+        subprocess.CalledProcessError: If MFA adaptation fails.
+    """
+    # Ensure dictionary is downloaded
+    ensure_dictionary_downloaded(dictionary_name)
 
     cmd = [
         "conda",


### PR DESCRIPTION
## Release Branch PR

**Target Release:** v0.1.0

### Changes

- **Fixed PyInstaller Build Issues**
  - Added custom NLTK hook to prevent collection of non-existent NLTK data files during build
  - NLTK resources now download at runtime instead of being bundled
  
- **Streamlined Engine Architecture**
  - Removed W2TG engine to simplify dependencies and reduce build complexity
  - Retained MFA and FasterWhisper engines as primary alignment tools
  
- **Enhanced MFA Configuration**
  - Added configurable dictionary selection for align and train operations
  - Renamed training "epochs" to "num_iterations" for accuracy (1-100 range)
  - Fixed settings file paths for consistency
  
- **Improved MFA Service Layer**
  - Added automatic dictionary download and validation
  - Implemented `ensure_dictionary_downloaded()` utility function
  - Added `--clean` flag to alignment commands to prevent cache issues
  
- **Configuration Updates**
  - Updated help URL from localhost to production: `https://voxkit-web.vercel.app/help`
  - Removed W2TG HuggingFace model download from startup routine

### Testing

- [x] Test testable logic
- [x] Edge cases addressed

**Testing Notes:**
- Successfully built macOS .app bundle with PyInstaller
- Verified NLTK resources download at runtime
- MFA alignment workflow tested with custom dictionary configuration
- Code signing and dylib path fixing verified on macOS

### Documentation

- [ ] README updated (if applicable)
- [x] Code comments added/updated
- [ ] User-facing documentation updated (if applicable)

**Documentation Notes:**
- Added comprehensive docstrings to MFA service functions
- PyInstaller hook includes clear explanation of runtime vs build-time data collection
- Settings tooltips improved for user clarity

### Checklist

- [x] Code follows project conventions
- [x] No breaking changes (or documented if intentional)
- [ ] All CI checks pass

**Notes:**
- W2TG engine removal is intentional to streamline the application
- Users will need to download NLTK data on first run (automatic via startup routine)
