### PR TITLE
Windows QA Sprint

### DIFF
--- a/QA_CHECKLIST.md
+++ b/QA_CHECKLIST.md
@@ -1,0 +1,75 @@
+# VoxKit — Interspeech 2026 Release Readiness Checklist
+
+Defines completeness criteria for VoxKit prior to Interspeech 2026, where Nina and Michael will present using the app.
+
+---
+
+## 1. Dataset Registration
+
+- [ ] Empty dataset fails with a descriptive popup
+- [ ] Valid dataset registers successfully
+- [ ] Valid dataset with optional hand alignments registers and ingests alignments
+- [ ] Cached dataset is properly ingested
+- [ ] `transcribed` flag is verified at registration:
+  - [ ] Marked transcribed but isn't → fails with descriptive popup
+  - [ ] Not marked transcribed but is → fails with descriptive popup
+- [ ] DeID label works for a valid dataset
+- [ ] Invalid folder structures are caught at registration time
+- [ ] Folder with valid structure but no audio files (determined by extension) fails registration
+
+## 2. Dataset Bundle Lifecycle
+
+Registration ingests a dataset into a VoxKit-compatible bundle. One user registers; others can import the bundle and skip validation/scanning/copying.
+
+- [ ] Import a registered dataset bundle (skips validation/scanning/copy)
+- [ ] Export a dataset bundle
+- [ ] Delete a dataset
+
+## 3. Dataset Analysis
+
+Analysis captures metadata via a class instantiated at registration time.
+
+- [ ] Analyze a dataset using 2+ methods
+- [ ] Metadata is captured correctly per method
+
+## 4. Model Registration
+
+Engines in scope: **W2TG** and **MFA**. Test 2 models per engine.
+
+- [ ] Register a model (×2 per engine)
+- [ ] Import a model (×2 per engine)
+- [ ] Export a model (×2 per engine)
+- [ ] Delete a model (×2 per engine)
+
+## 5. Transcription Pipeline
+
+- [ ] Transcribe audio with each of the 2 engine options
+- [ ] Custom settings: notable combinations either function correctly or give clear error feedback
+- [ ] Run transcription on every registered dataset from §1
+- [ ] Run transcription on every imported variant from §2
+- [ ] `transcribed = false` → transcription succeeds
+- [ ] `transcribed = true` → transcription fails (does not overwrite existing transcript files)
+
+## 6. Aligner Training
+
+- [ ] Train a new aligner using hand alignments, per engine
+- [ ] Validate different settings combinations (function correctly or give clear error feedback)
+
+## 7. Alignment Generation
+
+- [ ] Generate alignments for each dataset variant from import
+- [ ] Generate alignments using the newly trained models (edge-case coverage)
+
+## 8. Alignment Comparison Plots
+
+- [ ] Generate plots comparing alignment sets of the same dataset
+- [ ] All comparison-plot functionality exercised
+
+## 9. Praat-Style Alignment Viewer
+
+- [ ] View alignments in Praat-style visualization
+
+## 10. PLLR Score Plotting
+
+- [ ] Plot PLLR scores
+- [ ] Settings combinations function correctly or provide clear error feedback


### PR DESCRIPTION
# Windows QA Sprint

**Target:** v0.4.1 release that passes the [Interspeech 2026 QA checklist](https://github.com/BrainBehaviorAnalyticsLab/voxkit-desktop/blob/VOX-98-QA-Testing/QA_CHECKLIST.md) on Windows.

**Deadline driver:** Interspeech 2026 demo (Windows required).

---

## Branch strategy

`VOX-98-QA-Testing` is the integration buffer branched off `main`. QA work lands there, then merges into `release`, then back into `main` as v0.4.1.

```
main
 └── release                          ← stable release line
      └── VOX-98-QA-Testing           ← integration buffer (this effort)
           └── qa-windows-pass        ← Phase 1 (sole feature branch)
```

Merge path on completion: `qa-windows-pass` → `VOX-98-QA-Testing` → `release` → `main`.

---

## Phase 1 (Windows passes checklist)

**Branch:** `qa-windows-pass` off `VOX-98-QA-Testing`

- [ ] Set up Windows dev environment
- [ ] Run full QA checklist on Windows against current build
- [ ] File issue per failing criterion
- [ ] Fix Windows-specific issues; flag any change touching cross-platform code
- [ ] Run full QA checklist a second time on Windows to confirm no regressions from fixes

**Exit criteria:** All checklist items pass on Windows in a clean run.

---

## Phase 2 (Release v0.4.1)

- [ ] Merge `qa-windows-pass` → `VOX-98-QA-Testing`
- [ ] Merge `VOX-98-QA-Testing` → `release`
- [ ] Merge `release` → `main`
- [ ] Tag `v0.4.1-windows-VoxKit` on `main`
- [ ] Build + sign Windows installer
- [ ] Smoke test both artifacts on clean machines
- [ ] Publish release with checklist results attached

---

## Out of scope for v0.4.1

- Linux support
- Aspects breaking macos
- New features beyond what the checklist covers
- Performance optimization beyond demo-acceptable thresholds
- CI automation of the checklist (track separately)