### PR TITLE
Improve contrast for small text in textgrid viewer

### DIFF
--- a/src/voxkit/gui/pages/pipeline/viewer_stacker.py
+++ b/src/voxkit/gui/pages/pipeline/viewer_stacker.py
@@ -359,7 +359,7 @@ class TextGridTimeline(QWidget):
 
                 # Label inside block
                 if bw > 10 and iv_label:
-                    text_color = QColor("white") if (active or not silent) else color.darker(140)
+                    text_color = QColor("white") if active else color.darker(140)
                     painter.setPen(text_color)
                     painter.drawText(
                         x1 + 2,


### PR DESCRIPTION
This pull request makes a minor adjustment to the label color logic in the `paintEvent` method of `viewer_stacker.py`. The change ensures that the label text is only drawn in white when the block is active, regardless of the `silent` state.

* Simplified label text color logic so that text is white only if `active` is true; otherwise, it uses a darker color. (`src/voxkit/gui/pages/pipeline/viewer_stacker.py`)