### PR TITLE
Refactor: hoist dataset data-path helper to storage.datasets

### DIFF
--- a/src/voxkit/gui/pages/pipeline/pllr_stacker.py
+++ b/src/voxkit/gui/pages/pipeline/pllr_stacker.py
@@ -386,14 +386,7 @@ class PLLRStacker(QWidget):
             QMessageBox.warning(self, "Invalid Dataset", "Could not find dataset metadata.")
             return
 
-        wavlab_path: Path | str | None = None
-        if not (dataset_meta["cached"] == "True" or dataset_meta["cached"] is True):
-            wavlab_path = dataset_meta["original_path"]
-
-        else:
-            dataset_root = datasets._get_dataset_root(selected_dataset_id)
-            if dataset_root:
-                wavlab_path = dataset_root / "cache"
+        wavlab_path: Path | str | None = datasets.get_dataset_data_path(dataset_meta)
 
         print(f"[DEBUG] Dataset root path: {wavlab_path}")
 

--- a/src/voxkit/gui/pages/pipeline/training_stacker.py
+++ b/src/voxkit/gui/pages/pipeline/training_stacker.py
@@ -143,10 +143,7 @@ class TrainingStacker(BaseStacker):
             )
             return
 
-        if bool(dataset_metadata["cached"]):
-            audio_path = datasets._get_dataset_root(selected_dataset_id)
-        else:
-            audio_path = Path(dataset_metadata["original_path"])
+        audio_path = datasets.get_dataset_data_path(dataset_metadata)
 
         if not audio_path or not Path(audio_path).exists():
             QMessageBox.warning(

--- a/src/voxkit/gui/pages/pipeline/viewer_stacker.py
+++ b/src/voxkit/gui/pages/pipeline/viewer_stacker.py
@@ -40,7 +40,6 @@ from voxkit.gui.components import MultiColumnComboBox
 from voxkit.gui.pages.pipeline.base_stacker import BaseStacker
 from voxkit.gui.styles import Buttons, Colors, Containers, Labels
 from voxkit.storage import alignments, datasets
-from voxkit.storage.datasets import _get_dataset_root
 
 if TYPE_CHECKING:
     from PyQt6.QtMultimedia import QAudioOutput, QMediaPlayer
@@ -116,15 +115,6 @@ def _parse_textgrid(filepath: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 # Path helpers
 # ---------------------------------------------------------------------------
-
-
-def _dataset_data_path(meta: datasets.DatasetMetadata) -> Path:
-    """Return the directory containing speaker subdirs (audio + .lab files)."""
-    if meta.get("cached"):
-        root = _get_dataset_root(meta["id"])
-        if root:
-            return root / "cache"
-    return Path(meta["original_path"])
 
 
 def _find_textgrid(tg_root: Path, speaker: str, stem: str) -> Path | None:
@@ -694,7 +684,7 @@ class ViewerStacker(BaseStacker):
         if not self._current_dataset_meta:
             return
 
-        self._current_data_path = _dataset_data_path(self._current_dataset_meta)
+        self._current_data_path = datasets.get_dataset_data_path(self._current_dataset_meta)
 
         al_list = alignments.list_alignments(dataset_id)
         if al_list:

--- a/src/voxkit/storage/datasets.py
+++ b/src/voxkit/storage/datasets.py
@@ -101,6 +101,20 @@ def _get_dataset_root(dataset_id: str) -> Path | None:
     return None
 
 
+def get_dataset_data_path(meta: DatasetMetadata) -> Path | None:
+    """Return the directory containing the dataset's speaker subdirs.
+
+    For cached datasets this is ``<dataset_root>/cache``; for non-cached
+    datasets it is the original on-disk path recorded in metadata.
+    """
+    if meta.get("cached"):
+        root = _get_dataset_root(meta["id"])
+        if root is None:
+            return None
+        return root / "cache"
+    return Path(meta["original_path"])
+
+
 def _get_dataset_metadata(dataset_root: Path) -> DatasetMetadata | None:
     """Load dataset metadata from the given dataset root directory.
 


### PR DESCRIPTION
Extract get_dataset_data_path(meta) into voxkit.storage.datasets and use it from viewer_stacker, training_stacker, and pllr_stacker. The "cached -> root/cache, else original_path" rule now lives in one place next to _get_dataset_root.

Side-effect fixes:
- training_stacker previously passed the dataset root (not root/cache) as audio_path for cached datasets, inconsistent with the viewer and pllr paths. It now resolves to root/cache like the others.
- pllr_stacker dropped the brittle string "True"/bool dual-check on meta["cached"], matching the typed DatasetMetadata schema.