### PR TITLE
Out-of-box setup usability fixes

### DIFF
--- a/src/voxkit/config/startup_config.py
+++ b/src/voxkit/config/startup_config.py
@@ -77,7 +77,7 @@ def startup_routine():
     # Create folder for W2TG model
     w2tg_path = storage_root / "W2TGENGINE" / MODELS_ROOT
     w2tg_path.mkdir(parents=True, exist_ok=True)
-    success, metadata = models.create_model("W2TGENGINE", "prads_model")
+    success, metadata = models.create_model("W2TGENGINE", "default")
     if not success:
         print(f"[STARTUP] Failed to create model metadata. {metadata}")
         return

--- a/src/voxkit/gui/frameworks/settings_modal/api.py
+++ b/src/voxkit/gui/frameworks/settings_modal/api.py
@@ -14,6 +14,8 @@ class FieldType(Enum):
         CHECKBOX: Boolean toggle field (ToggleSwitch)
         LINEEDIT: Text input field (QLineEdit)
         COMBOBOX: Dropdown selection field (QComboBox)
+        DIRPATH: Text input field (QLineEdit) with a "Browse..." button that
+            opens a native directory picker and fills in the selected path.
     """
 
     SPINBOX = "spinbox"
@@ -21,6 +23,7 @@ class FieldType(Enum):
     CHECKBOX = "checkbox"
     LINEEDIT = "lineedit"
     COMBOBOX = "combobox"
+    DIRPATH = "dirpath"
 
 
 @dataclass

--- a/src/voxkit/gui/frameworks/settings_modal/generic.py
+++ b/src/voxkit/gui/frameworks/settings_modal/generic.py
@@ -278,7 +278,7 @@ class GenericDialog(QDialog):
             A container widget with the line edit and button side by side,
             or the original widget unchanged for other field types.
         """
-        if config.field_type != FieldType.DIRPATH:
+        if config.field_type != FieldType.DIRPATH or not isinstance(widget, QLineEdit):
             return widget
 
         container = QWidget()

--- a/src/voxkit/gui/frameworks/settings_modal/generic.py
+++ b/src/voxkit/gui/frameworks/settings_modal/generic.py
@@ -10,6 +10,7 @@ from PyQt6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QDoubleSpinBox,
+    QFileDialog,
     QFormLayout,
     QGraphicsBlurEffect,
     QHBoxLayout,
@@ -262,7 +263,43 @@ class GenericDialog(QDialog):
         for field_config in self.field_configs:
             widget = self._create_field_widget(field_config)
             self.field_widgets[field_config.name] = widget
-            self.form_layout.addRow(field_config.label, widget)
+            row_widget = self._wrap_with_browse_button(widget, field_config)
+            self.form_layout.addRow(field_config.label, row_widget)
+
+    def _wrap_with_browse_button(self, widget: QWidget, config: FieldConfig) -> QWidget:
+        """
+        Pair a DIRPATH field's line edit with a "Browse..." button.
+
+        Args:
+            widget: The line edit widget created for this field.
+            config: Field configuration; only DIRPATH fields get a button.
+
+        Returns:
+            A container widget with the line edit and button side by side,
+            or the original widget unchanged for other field types.
+        """
+        if config.field_type != FieldType.DIRPATH:
+            return widget
+
+        container = QWidget()
+        row_layout = QHBoxLayout(container)
+        row_layout.setContentsMargins(0, 0, 0, 0)
+        row_layout.addWidget(widget)
+
+        browse_btn = QPushButton("Browse...")
+        browse_btn.setStyleSheet(Buttons.SECONDARY)
+        browse_btn.clicked.connect(lambda: self._browse_for_directory(widget))
+        row_layout.addWidget(browse_btn)
+
+        return container
+
+    def _browse_for_directory(self, lineedit: QLineEdit) -> None:
+        """Open a directory picker and write the chosen path into ``lineedit``."""
+        current = lineedit.text().strip()
+        start_dir = current if current and Path(current).exists() else str(Path.home())
+        directory = QFileDialog.getExistingDirectory(self, "Select Directory", start_dir)
+        if directory:
+            lineedit.setText(directory)
 
     def _create_field_widget(self, config: FieldConfig) -> QWidget:
         """
@@ -289,6 +326,8 @@ class GenericDialog(QDialog):
         elif config.field_type == FieldType.CHECKBOX:
             widget = ToggleSwitch(checked=bool(config.default_value))
         elif config.field_type == FieldType.LINEEDIT:
+            widget = self._create_lineedit(config)
+        elif config.field_type == FieldType.DIRPATH:
             widget = self._create_lineedit(config)
         elif config.field_type == FieldType.COMBOBOX:
             widget = self._create_combobox(config)

--- a/src/voxkit/gui/pages/datasets/datasets_page.py
+++ b/src/voxkit/gui/pages/datasets/datasets_page.py
@@ -650,16 +650,16 @@ class DatasetsPage(QWidget):
         # Create settings config
         config = SettingsConfig(
             title="Register New Dataset",
-            dimensions=(500, 400),
+            dimensions=(500, 460),
             apply_blur=False,  # Disable blur to avoid parent issues
             store_file="dataset_registration_settings.json",
             fields=[
                 FieldConfig(
                     name="dataset_path",
                     label="Dataset Path",
-                    field_type=FieldType.LINEEDIT,
+                    field_type=FieldType.DIRPATH,
                     default_value="",
-                    placeholder="Browse for dataset directory...",
+                    placeholder="e.g., /home/corpora/timit_train",
                     tooltip="Root directory containing speaker subdirectories",
                 ),
                 FieldConfig(
@@ -710,9 +710,9 @@ class DatasetsPage(QWidget):
                 FieldConfig(
                     name="hand_alignments_path",
                     label="Hand Alignments Path",
-                    field_type=FieldType.LINEEDIT,
+                    field_type=FieldType.DIRPATH,
                     default_value="",
-                    placeholder="Optional: path to pre-existing TextGrids...",
+                    placeholder="Optional: directory of pre-existing TextGrids",
                     tooltip="Optional directory containing hand-annotated TextGrid files",
                 ),
             ],
@@ -782,13 +782,6 @@ class DatasetsPage(QWidget):
         self.registration_worker.progress.connect(self.show_progress)
         self.registration_worker.finished.connect(self.registration_complete)
         self.registration_worker.start()
-
-    def browse_dataset_path(self):
-        """Open directory picker for dataset path"""
-        directory = QFileDialog.getExistingDirectory(self, "Select Dataset Root Directory")
-        if directory:
-            return directory
-        return None
 
     def show_progress(self, message):
         """Show progress message"""

--- a/src/voxkit/gui/pages/datasets/datasets_page.py
+++ b/src/voxkit/gui/pages/datasets/datasets_page.py
@@ -35,7 +35,7 @@ from voxkit.gui.components.csv_viewer_dialog import CSVViewerDialog
 from voxkit.gui.styles import Buttons, Containers, Labels
 from voxkit.gui.workers import DatasetRegistrationWorker
 from voxkit.storage import alignments, datasets
-from voxkit.storage.alignments import HAND_ALIGNMENT_SENTINEL, AlignmentMetadata
+from voxkit.storage.alignments import HAND_ALIGNMENT_SENTINEL, AlignmentMetadata, get_alignment_type
 from voxkit.storage.datasets import DatasetMetadata
 
 # Virtual engine ids that are not registered in the engines registry but may
@@ -273,11 +273,12 @@ class DatasetsPage(QWidget):
 
         # Dataset table
         self.dataset_table = QTableWidget()
-        self.dataset_table.setColumnCount(7)
+        self.dataset_table.setColumnCount(8)
         self.dataset_table.setHorizontalHeaderLabels(
             [
                 "Name",
                 "Description",
+                "Location",
                 "Cached",
                 "De-identified",
                 "Transcribed",
@@ -291,10 +292,14 @@ class DatasetsPage(QWidget):
         if header is not None:
             header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
             header.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
-            for i in range(2, 6):
+            header.setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)
+            for i in range(3, 7):
                 header.setSectionResizeMode(i, QHeaderView.ResizeMode.ResizeToContents)
-            header.setSectionResizeMode(6, QHeaderView.ResizeMode.Fixed)
-        self.dataset_table.setColumnWidth(6, 100)
+            header.setSectionResizeMode(7, QHeaderView.ResizeMode.Fixed)
+        self.dataset_table.setColumnWidth(7, 100)
+        # Elide long paths (Location column) from the left so the distinguishing
+        # tail of the path stays visible instead of the shared "C:\Users\..." prefix.
+        self.dataset_table.setTextElideMode(Qt.TextElideMode.ElideLeft)
 
         self.dataset_table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
         self.dataset_table.setSelectionMode(QTableWidget.SelectionMode.SingleSelection)
@@ -374,9 +379,9 @@ class DatasetsPage(QWidget):
 
         # Alignments table
         self.alignments_table = QTableWidget()
-        self.alignments_table.setColumnCount(5)
+        self.alignments_table.setColumnCount(7)
         self.alignments_table.setHorizontalHeaderLabels(
-            ["Engine", "Model", "Date Aligned", "Status", "Actions"]
+            ["Engine", "Model", "Type", "Location", "Date Aligned", "Status", "Actions"]
         )
 
         # Configure alignments table
@@ -385,9 +390,14 @@ class DatasetsPage(QWidget):
             align_header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
             align_header.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
             align_header.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
-            align_header.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
-            align_header.setSectionResizeMode(4, QHeaderView.ResizeMode.Fixed)
-        self.alignments_table.setColumnWidth(4, 150)
+            align_header.setSectionResizeMode(3, QHeaderView.ResizeMode.Stretch)
+            align_header.setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)
+            align_header.setSectionResizeMode(5, QHeaderView.ResizeMode.ResizeToContents)
+            align_header.setSectionResizeMode(6, QHeaderView.ResizeMode.Fixed)
+        self.alignments_table.setColumnWidth(6, 150)
+        # Elide long paths (Location column) from the left so the distinguishing
+        # tail of the path stays visible instead of the shared "C:\Users\..." prefix.
+        self.alignments_table.setTextElideMode(Qt.TextElideMode.ElideLeft)
 
         # Disable selection and editing
         self.alignments_table.setSelectionMode(QTableWidget.SelectionMode.NoSelection)
@@ -501,10 +511,24 @@ class DatasetsPage(QWidget):
             model_item.setFont(font)
             self.alignments_table.setItem(row, 1, model_item)
 
+            # Type — provenance (automatic/hand/corrected), distinguishes a corrected
+            # alignment from the automatic one it was derived from, since they
+            # otherwise share the same engine/model.
+            type_item = QTableWidgetItem(get_alignment_type(alignment))
+            type_item.setFlags(type_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+            self.alignments_table.setItem(row, 2, type_item)
+
+            # Location — filesystem path to the alignment's TextGrid output
+            location = alignment.get("tg_path", "Unknown")
+            location_item = QTableWidgetItem(location)
+            location_item.setFlags(location_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+            location_item.setToolTip(location)
+            self.alignments_table.setItem(row, 3, location_item)
+
             # Date Aligned
             date_item = QTableWidgetItem(alignment["alignment_date"])
             date_item.setFlags(date_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
-            self.alignments_table.setItem(row, 2, date_item)
+            self.alignments_table.setItem(row, 4, date_item)
 
             # Status
             status_item = QTableWidgetItem(alignment.get("status", "Unknown"))
@@ -516,11 +540,11 @@ class DatasetsPage(QWidget):
                 status_item.setForeground(Qt.GlobalColor.darkYellow)
             elif status == "failed":
                 status_item.setForeground(Qt.GlobalColor.red)
-            self.alignments_table.setItem(row, 3, status_item)
+            self.alignments_table.setItem(row, 4, status_item)
 
             # Actions
             actions_widget = self._create_alignment_action_buttons(alignment)
-            self.alignments_table.setCellWidget(row, 4, actions_widget)
+            self.alignments_table.setCellWidget(row, 5, actions_widget)
 
         # Disconnect old connections and connect cell click for model column
         try:
@@ -806,29 +830,35 @@ class DatasetsPage(QWidget):
             desc_item.setToolTip(meta["description"])
             self.dataset_table.setItem(index, 1, desc_item)
 
+            # Location — original corpus filesystem path (always recorded, even when cached)
+            location = meta.get("original_path", "Unknown")
+            location_item = QTableWidgetItem(location)
+            location_item.setToolTip(location)
+            self.dataset_table.setItem(index, 2, location_item)
+
             # Cached
             self.dataset_table.setItem(
-                index, 2, QTableWidgetItem("Yes" if meta["cached"] else "No")
+                index, 3, QTableWidgetItem("Yes" if meta["cached"] else "No")
             )
 
             # Anonymized
             self.dataset_table.setItem(
-                index, 3, QTableWidgetItem("Yes" if meta["anonymize"] else "No")
+                index, 4, QTableWidgetItem("Yes" if meta["anonymize"] else "No")
             )
 
             self.dataset_table.setItem(
-                index, 4, QTableWidgetItem("Yes" if meta.get("transcribed", False) else "No")
+                index, 5, QTableWidgetItem("Yes" if meta.get("transcribed", False) else "No")
             )
 
             # Registration date
             reg_date = meta.get("registration_date", "Unknown")
             if reg_date != "Unknown":
                 reg_date = reg_date.split("T")[0]  # Show only date part
-            self.dataset_table.setItem(index, 5, QTableWidgetItem(reg_date))
+            self.dataset_table.setItem(index, 6, QTableWidgetItem(reg_date))
 
             # Actions - Details button
             actions_widget = self._create_dataset_action_buttons(meta)
-            self.dataset_table.setCellWidget(index, 6, actions_widget)
+            self.dataset_table.setCellWidget(index, 7, actions_widget)
 
     def _create_dataset_action_buttons(self, dataset_meta: DatasetMetadata):
         """Create action buttons for a dataset row.

--- a/src/voxkit/gui/pages/models/models_page.py
+++ b/src/voxkit/gui/pages/models/models_page.py
@@ -193,16 +193,16 @@ class ManageAlignersWidget(CategoricalTableWidget):
         # Create settings config
         config = SettingsConfig(
             title="Register New Model",
-            dimensions=(400, 250),
+            dimensions=(400, 320),
             apply_blur=False,
             store_file="model_registration_settings.json",
             fields=[
                 FieldConfig(
                     name="model_path",
                     label="Model Path",
-                    field_type=FieldType.LINEEDIT,
+                    field_type=FieldType.DIRPATH,
                     default_value="",
-                    placeholder="Browse for model directory...",
+                    placeholder="e.g., /home/acoustic-models",
                     tooltip="Path to the model directory or file",
                 ),
                 FieldConfig(

--- a/src/voxkit/gui/pages/pipeline/base_stacker.py
+++ b/src/voxkit/gui/pages/pipeline/base_stacker.py
@@ -8,9 +8,16 @@ API
 """
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QProgressBar,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
 
-from voxkit.gui.styles import Buttons, Labels
+from voxkit.gui.styles import Buttons, Containers, Labels
 
 
 class BaseStacker(QWidget):
@@ -40,6 +47,7 @@ class BaseStacker(QWidget):
         super().__init__(parent)
         self._parent_widget = parent
         self.status_label: QLabel | None = None
+        self.progress_bar: QProgressBar | None = None
         self.main_layout: QVBoxLayout
         self.content_layout: QVBoxLayout
         self.init_ui()
@@ -92,11 +100,20 @@ class BaseStacker(QWidget):
         self.main_layout.addLayout(header_layout)
 
     def _create_status_label(self):
-        """Create the standard status label."""
+        """Create the standard status label and its indeterminate progress bar."""
         self.status_label = QLabel("Ready")
         self.status_label.setStyleSheet(Labels.STATUS_READY)
         self.status_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.main_layout.addWidget(self.status_label)
+
+        # Indeterminate (busy) bar: range (0, 0) makes Qt render a bouncing
+        # bar instead of a percentage, since work here has no known progress.
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setRange(0, 0)
+        self.progress_bar.setTextVisible(False)
+        self.progress_bar.setStyleSheet(Containers.PROGRESS_BAR)
+        self.progress_bar.setVisible(False)
+        self.main_layout.addWidget(self.progress_bar)
 
     def set_status(self, message: str, status_type: str = "ready"):
         """Set the status label text and styling.
@@ -117,6 +134,9 @@ class BaseStacker(QWidget):
 
         self.status_label.setText(message)
         self.status_label.setStyleSheet(status_styles.get(status_type, Labels.STATUS_READY))
+
+        if self.progress_bar:
+            self.progress_bar.setVisible(status_type == "working")
 
     # Methods for subclasses to override
 

--- a/src/voxkit/gui/pages/pipeline/pllr_stacker.py
+++ b/src/voxkit/gui/pages/pipeline/pllr_stacker.py
@@ -14,6 +14,9 @@ Notes
 - Outputs phonewise and framewise probability CSVs
 """
 
+import csv
+import re
+from datetime import datetime
 from pathlib import Path
 
 from pypllrcomputer import compute_pllr
@@ -25,6 +28,7 @@ from PyQt6.QtWidgets import (
     QLabel,
     QLineEdit,
     QMessageBox,
+    QProgressBar,
     QPushButton,
     QVBoxLayout,
     QWidget,
@@ -108,6 +112,66 @@ def get_pllr_settings_config() -> SettingsConfig:
         fields=fields,
         store_file="pllr_settings.json",
     )
+
+
+def _append_run_metadata_to_csv(csv_path: str, run_metadata: dict[str, str]) -> None:
+    """Append run metadata columns to every row of a GOP output CSV, in place.
+
+    Why: compute_pllr() (external pypllrcomputer package) writes phonewise/
+    framewise CSVs with no provenance info, making it impossible to trace a
+    results file back to the corpus, engine, and model that produced it once
+    it's been moved or shared. Appending columns here avoids touching the
+    external package.
+
+    Args:
+        csv_path: Path to the CSV file to enrich. No-op if it doesn't exist.
+        run_metadata: Column name -> value pairs appended to every row.
+    """
+    path = Path(csv_path)
+    if not path.exists():
+        return
+
+    with open(path, "r", encoding="utf-8", newline="") as f:
+        rows = list(csv.reader(f))
+
+    if not rows:
+        return
+
+    header, *data_rows = rows
+    metadata_columns = list(run_metadata.keys())
+    metadata_values = [run_metadata[key] for key in metadata_columns]
+
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(header + metadata_columns)
+        writer.writerows(row + metadata_values for row in data_rows)
+
+
+def _sanitize_filename_part(text: str) -> str:
+    """Make a string safe to embed in a filename across platforms."""
+    cleaned = re.sub(r"[^A-Za-z0-9_-]+", "_", text.strip())
+    return cleaned.strip("_") or "unknown"
+
+
+def _rename_with_run_metadata(
+    csv_path: str, corpus_name: str, engine_id: str, date_stamp: str
+) -> str:
+    """Rename a GOP output CSV to embed corpus/engine/date, returning the new path.
+
+    Why: the appended metadata columns identify a file's provenance once
+    opened, but don't help distinguish files at a glance in a file browser
+    when working across multiple corpora, engines, or runs.
+    """
+    path = Path(csv_path)
+    if not path.exists():
+        return csv_path
+
+    suffix = "_".join(
+        _sanitize_filename_part(part) for part in (corpus_name, engine_id, date_stamp)
+    )
+    new_path = path.with_name(f"{path.stem}_{suffix}{path.suffix}")
+    path.rename(new_path)
+    return str(new_path)
 
 
 class PLLRStacker(QWidget):
@@ -299,6 +363,15 @@ class PLLRStacker(QWidget):
         self.extract_status.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self.extract_status)
 
+        # Indeterminate (busy) bar: range (0, 0) makes Qt render a bouncing
+        # bar instead of a percentage, since work here has no known progress.
+        self.extract_progress = QProgressBar()
+        self.extract_progress.setRange(0, 0)
+        self.extract_progress.setTextVisible(False)
+        self.extract_progress.setStyleSheet(Containers.PROGRESS_BAR)
+        self.extract_progress.setVisible(False)
+        layout.addWidget(self.extract_progress)
+
         layout.addStretch()
         return self
 
@@ -429,19 +502,24 @@ class PLLRStacker(QWidget):
         # Update UI
         self.extract_status.setText("Processing...")
         self.extract_status.setStyleSheet("color: #f39c12; font-size: 12px; margin-top: 5px;")
+        self.extract_progress.setVisible(True)
         self.extract_btn.setEnabled(False)
 
         print("[DEBUG] Starting worker thread...")
 
         # Start worker thread
         self.worker = WorkerThread(
-            lambda: self.extract_pllr_logic(textgrid_path, wavlab_path, output_path)
+            lambda: self.extract_pllr_logic(
+                textgrid_path, wavlab_path, output_path, dataset_meta, alignment_data
+            )
         )
         self.worker.finished.connect(self.on_extract_finished)
         self.worker.start()
         print("[DEBUG] Worker thread started")
 
-    def extract_pllr_logic(self, textgrid_path, wavlab_path, output_path):
+    def extract_pllr_logic(
+        self, textgrid_path, wavlab_path, output_path, dataset_meta=None, alignment_data=None
+    ):
         """Actual PLLR extraction logic"""
 
         print("\n=== EXTRACT PLLR LOGIC ===")
@@ -537,6 +615,46 @@ class PLLRStacker(QWidget):
                 aggregation_function=agg_fn,
             )
             print("[LOGIC] compute_pllr() completed successfully")
+
+            model_metadata = (alignment_data or {}).get("model_metadata") or {}
+            now = datetime.now()
+            run_metadata = {
+                "run_datetime": now.isoformat(timespec="seconds"),
+                "corpus_name": (dataset_meta or {}).get("name", ""),
+                "corpus_id": (dataset_meta or {}).get("id", ""),
+                "engine_id": (alignment_data or {}).get("engine_id", ""),
+                "model_name": model_metadata.get("name", ""),
+                "model_id": model_metadata.get("id", ""),
+            }
+            # Full timestamp (not just date) so multiple runs on the same day
+            # against the same corpus/engine never collide on rename below.
+            date_stamp = now.strftime("%Y%m%d_%H%M%S")
+
+            # compute_pllr() writes phonewise_path verbatim only when the
+            # aggregation function returns a single DataFrame. Aggregations
+            # like aggregate_by_phoneme_occurrence return a dict of
+            # per-statistic DataFrames instead, written to
+            # "{stem}_{method}.csv" (e.g. phonewise_proba_mean.csv) — so glob
+            # for every variant rather than assuming the literal filename.
+            phonewise_stem = Path(phonewise_path).stem
+            phonewise_outputs = list(Path(phonewise_path).parent.glob(f"{phonewise_stem}*.csv"))
+            if not phonewise_outputs:
+                print(f"[WARN] No phonewise output CSVs found matching {phonewise_stem}*.csv")
+
+            output_paths = [*phonewise_outputs, Path(framewise_path)]
+            renamed_paths = []
+            for csv_path in output_paths:
+                _append_run_metadata_to_csv(str(csv_path), run_metadata)
+                renamed_paths.append(
+                    _rename_with_run_metadata(
+                        str(csv_path),
+                        run_metadata["corpus_name"],
+                        run_metadata["engine_id"],
+                        date_stamp,
+                    )
+                )
+            print(f"[LOGIC] Appended run metadata and renamed output CSVs: {renamed_paths}")
+
             return "PLLR extracted successfully"
         except Exception as e:
             print(f"[ERROR] Exception in compute_pllr(): {type(e).__name__}")
@@ -553,6 +671,7 @@ class PLLRStacker(QWidget):
         print(f"[FINISHED] Message: {message}")
 
         self.extract_btn.setEnabled(True)
+        self.extract_progress.setVisible(False)
 
         if success:
             print("[FINISHED] Extraction completed successfully")

--- a/src/voxkit/gui/styles/__init__.py
+++ b/src/voxkit/gui/styles/__init__.py
@@ -637,6 +637,19 @@ class Containers:
         }
     """
 
+    PROGRESS_BAR = f"""
+        QProgressBar {{
+            border: 1px solid {Colors.BORDER};
+            border-radius: 4px;
+            background-color: {Colors.BG_SECONDARY};
+            max-height: 6px;
+        }}
+        QProgressBar::chunk {{
+            background-color: {Colors.PRIMARY};
+            border-radius: 4px;
+        }}
+    """
+
     GROUP_BOX = """
         QGroupBox {
             font-weight: bold;

--- a/src/voxkit/storage/alignments.py
+++ b/src/voxkit/storage/alignments.py
@@ -19,6 +19,7 @@ API
 - **create_alignment**: Create a new alignment entry in storage
 - **create_hand_alignment**: Create a new hand-annotated alignment entry in storage
 - **get_alignment_metadata**: Retrieve metadata for a specific alignment
+- **get_alignment_type**: Return an alignment's provenance (automatic/hand/corrected)
 - **update_alignment**: Update the status or details of an existing alignment
 - **list_alignments**: List all alignments for a given dataset
 - **delete_alignment**: Remove an alignment from storage
@@ -36,7 +37,7 @@ import json
 import os
 import shutil
 from pathlib import Path
-from typing import List, Literal, Tuple, TypedDict
+from typing import List, Literal, NotRequired, Tuple, TypedDict
 
 from .constants import ALIGNMENTS_ROOT, SUPERSET_AUDIO_EXTENSIONS
 from .datasets import _get_dataset_root, get_dataset_metadata
@@ -56,6 +57,10 @@ Values:
 """
 
 
+AlignmentType = Literal["automatic", "hand", "corrected"]
+"""Provenance of an alignment: model-generated, hand-annotated, or user-corrected."""
+
+
 class AlignmentMetadata(TypedDict):
     """Alignment metadata structure.
 
@@ -67,6 +72,9 @@ class AlignmentMetadata(TypedDict):
         alignment_date: Human-readable alignment creation timestamp.
         status: Current status of the alignment operation.
         tg_path: Path to the directory containing TextGrid output files.
+        alignment_type: Provenance of the alignment. Absent on alignments created
+            before this field existed -- use `get_alignment_type()` rather than
+            reading this key directly.
     """
 
     id: str
@@ -76,6 +84,21 @@ class AlignmentMetadata(TypedDict):
     alignment_date: str
     status: AlignmentStatus
     tg_path: str
+    alignment_type: NotRequired[AlignmentType]
+
+
+def get_alignment_type(meta: AlignmentMetadata) -> str:
+    """Return the alignment's type, inferring it for alignments predating this field.
+
+    Alignments written before `alignment_type` existed don't have the key in their
+    on-disk JSON at all -- infer "hand" from the legacy `engine_id` sentinel and
+    otherwise default to "automatic".
+    """
+    if "alignment_type" in meta:
+        return meta["alignment_type"]
+    if meta.get("engine_id") == HAND_ALIGNMENT_SENTINEL:
+        return "hand"
+    return "automatic"
 
 
 def _get_alignments_root(dataset_id: str) -> Path | None:

--- a/tests/gui/test_datasets_page.py
+++ b/tests/gui/test_datasets_page.py
@@ -48,3 +48,122 @@ class TestRefreshDatasets:
         assert datasets_page.empty_label.isHidden()
         assert not datasets_page.dataset_table.isHidden()
         assert datasets_page.dataset_table.rowCount() == 1
+
+    def test_location_column_shows_original_path(self, qtbot, datasets_page):
+        sample_metadata = [
+            {
+                "id": "ds-1",
+                "name": "Test Dataset",
+                "description": "A test dataset",
+                "original_path": r"C:\corpora\timit_train",
+                "cached": True,
+                "anonymize": False,
+                "transcribed": False,
+                "registration_date": "2024-01-01T00:00:00",
+            }
+        ]
+        with patch(
+            "voxkit.gui.pages.datasets.datasets_page.datasets.list_datasets_metadata",
+            return_value=sample_metadata,
+        ):
+            datasets_page.refresh_datasets()
+
+        location_item = datasets_page.dataset_table.item(0, 2)
+        assert location_item.text() == r"C:\corpora\timit_train"
+        assert location_item.toolTip() == r"C:\corpora\timit_train"
+
+    def test_location_column_falls_back_when_missing(self, qtbot, datasets_page):
+        sample_metadata = [
+            {
+                "id": "ds-1",
+                "name": "Test Dataset",
+                "description": "A test dataset",
+                "cached": False,
+                "anonymize": False,
+                "transcribed": False,
+                "registration_date": "2024-01-01T00:00:00",
+            }
+        ]
+        with patch(
+            "voxkit.gui.pages.datasets.datasets_page.datasets.list_datasets_metadata",
+            return_value=sample_metadata,
+        ):
+            datasets_page.refresh_datasets()
+
+        assert datasets_page.dataset_table.item(0, 2).text() == "Unknown"
+
+
+class TestDisplayAlignments:
+    def test_location_column_shows_tg_path(self, qtbot, datasets_page):
+        sample_alignment = {
+            "id": "align-1",
+            "engine_id": "mfa",
+            "model_metadata": {"id": "model-1", "name": "Test Model"},
+            "alignment_date": "2024-01-01T00:00:00",
+            "status": "completed",
+            "tg_path": r"C:\voxkit_storage\datasets\ds-1\alignments\align-1\textgrids",
+        }
+
+        datasets_page._display_alignments([sample_alignment])
+
+        location_item = datasets_page.alignments_table.item(0, 3)
+        assert location_item.text() == sample_alignment["tg_path"]
+        assert location_item.toolTip() == sample_alignment["tg_path"]
+
+    def test_location_column_falls_back_when_missing(self, qtbot, datasets_page):
+        sample_alignment = {
+            "id": "align-1",
+            "engine_id": "mfa",
+            "model_metadata": {"id": "model-1", "name": "Test Model"},
+            "alignment_date": "2024-01-01T00:00:00",
+            "status": "completed",
+        }
+
+        datasets_page._display_alignments([sample_alignment])
+
+        assert datasets_page.alignments_table.item(0, 3).text() == "Unknown"
+
+    def test_type_column_shows_corrected_for_corrected_alignment(self, qtbot, datasets_page):
+        sample_alignment = {
+            "id": "align-2",
+            "engine_id": "MFAENGINE",
+            "model_metadata": {"id": "model-1", "name": "Test Model"},
+            "alignment_date": "2024-01-01T00:00:00",
+            "status": "completed",
+            "tg_path": r"C:\voxkit_storage\datasets\ds-1\alignments\align-2\textgrids",
+            "source_alignment_id": "align-1",
+            "alignment_type": "corrected",
+        }
+
+        datasets_page._display_alignments([sample_alignment])
+
+        assert datasets_page.alignments_table.item(0, 2).text() == "corrected"
+
+    def test_type_column_defaults_to_automatic_for_legacy_alignment(self, qtbot, datasets_page):
+        """Alignments predating the alignment_type field should read as "automatic"."""
+        sample_alignment = {
+            "id": "align-1",
+            "engine_id": "MFAENGINE",
+            "model_metadata": {"id": "model-1", "name": "Test Model"},
+            "alignment_date": "2024-01-01T00:00:00",
+            "status": "completed",
+            "tg_path": r"C:\voxkit_storage\datasets\ds-1\alignments\align-1\textgrids",
+        }
+
+        datasets_page._display_alignments([sample_alignment])
+
+        assert datasets_page.alignments_table.item(0, 2).text() == "automatic"
+
+    def test_type_column_shows_hand_for_hand_alignment_sentinel(self, qtbot, datasets_page):
+        sample_alignment = {
+            "id": "hand",
+            "engine_id": "hand",
+            "model_metadata": {"id": "hand", "name": "hand"},
+            "alignment_date": "2024-01-01T00:00:00",
+            "status": "completed",
+            "tg_path": r"C:\voxkit_storage\datasets\ds-1\alignments\hand\textgrids",
+        }
+
+        datasets_page._display_alignments([sample_alignment])
+
+        assert datasets_page.alignments_table.item(0, 2).text() == "hand"

--- a/tests/storage/test_alignments.py
+++ b/tests/storage/test_alignments.py
@@ -107,7 +107,7 @@ class TestAlignments:
             assert isinstance(result, dict)
 
             # Verify all required keys are present
-            required_keys = set(AlignmentMetadata.__annotations__.keys())
+            required_keys = set(AlignmentMetadata.__required_keys__)
             assert required_keys.issubset(set(result.keys()))
 
             # Verify field values
@@ -192,7 +192,7 @@ class TestAlignments:
         assert isinstance(result, dict)
 
         # Verify all required keys are present
-        required_keys = set(AlignmentMetadata.__annotations__.keys())
+        required_keys = set(AlignmentMetadata.__required_keys__)
         assert required_keys.issubset(set(result.keys()))
 
         # Verify field values
@@ -591,3 +591,26 @@ class TestAlignments:
 
             assert fetched_metadata is not None
             assert fetched_metadata["status"] == "failed"  # Should be lowercase
+
+
+class TestGetAlignmentType:
+    """get_alignment_type() must read the recorded field, and infer for legacy data
+    that predates the alignment_type field entirely."""
+
+    def test_returns_recorded_type(self):
+        from voxkit.storage.alignments import get_alignment_type
+
+        meta = {"engine_id": "MFAENGINE", "alignment_type": "corrected"}
+        assert get_alignment_type(meta) == "corrected"
+
+    def test_infers_hand_from_legacy_sentinel(self):
+        from voxkit.storage.alignments import HAND_ALIGNMENT_SENTINEL, get_alignment_type
+
+        meta = {"engine_id": HAND_ALIGNMENT_SENTINEL}
+        assert get_alignment_type(meta) == "hand"
+
+    def test_defaults_to_automatic_for_legacy_data(self):
+        from voxkit.storage.alignments import get_alignment_type
+
+        meta = {"engine_id": "MFAENGINE"}
+        assert get_alignment_type(meta) == "automatic"


### PR DESCRIPTION
Usability fixes found during out-of-box QA testing:

- Working browse button on the Register New Model dialog (native QFileDialog instead of a broken/missing picker).
- Shared progress bar on every pipeline stacker's processing status (previously no feedback while a step was running).
- PLLR extraction gets a progress bar plus run-metadata columns (run_datetime/corpus_name/corpus_id/engine_id/model_name/model_id) appended to its output CSVs, with output files named to include corpus/engine/timestamp so repeated runs don't overwrite each other.
- Renamed the default W2TG model display name from `prads_model` to `default` for fresh installs.
- Dataset Management page now shows filesystem locations: a "Location" column on the datasets table (the corpus's original path) and on the alignments table (each alignment's TextGrid output path), plus a "Type" column on the alignments table so a corrected alignment is distinguishable from the automatic one it was derived from. Long paths elide from the left (showing the distinguishing tail) instead of the default right-elide, with the full path always available via tooltip.
