### PR TITLE
Add clearer tooltips to the Register New Dataset page

### DIFF
--- a/src/voxkit/gui/frameworks/settings_modal/generic.py
+++ b/src/voxkit/gui/frameworks/settings_modal/generic.py
@@ -264,7 +264,12 @@ class GenericDialog(QDialog):
             widget = self._create_field_widget(field_config)
             self.field_widgets[field_config.name] = widget
             row_widget = self._wrap_with_browse_button(widget, field_config)
-            self.form_layout.addRow(field_config.label, row_widget)
+            # Use an explicit label so the tooltip is also shown when hovering the
+            # field's label text, not just its input widget.
+            label = QLabel(field_config.label)
+            if field_config.tooltip:
+                label.setToolTip(field_config.tooltip)
+            self.form_layout.addRow(label, row_widget)
 
     def _wrap_with_browse_button(self, widget: QWidget, config: FieldConfig) -> QWidget:
         """

--- a/src/voxkit/gui/pages/datasets/datasets_page.py
+++ b/src/voxkit/gui/pages/datasets/datasets_page.py
@@ -650,8 +650,7 @@ class DatasetsPage(QWidget):
         # Build the Analysis Method tooltip from each analyzer's own description
         # so it stays accurate as analyzers are added or changed.
         analyzer_lines = [
-            f"<b>{a.name}:</b> {a.description}"
-            for a in ManageAnalyzers.get_analyzers().values()
+            f"<b>{a.name}:</b> {a.description}" for a in ManageAnalyzers.get_analyzers().values()
         ]
         analysis_tooltip = (
             "Chooses how the dataset summary CSV is generated. Options:<br>"

--- a/src/voxkit/gui/pages/datasets/datasets_page.py
+++ b/src/voxkit/gui/pages/datasets/datasets_page.py
@@ -647,6 +647,17 @@ class DatasetsPage(QWidget):
             SettingsConfig,
         )
 
+        # Build the Analysis Method tooltip from each analyzer's own description
+        # so it stays accurate as analyzers are added or changed.
+        analyzer_lines = [
+            f"<b>{a.name}:</b> {a.description}"
+            for a in ManageAnalyzers.get_analyzers().values()
+        ]
+        analysis_tooltip = (
+            "Chooses how the dataset summary CSV is generated. Options:<br>"
+            + "<br>".join(analyzer_lines)
+        )
+
         # Create settings config
         config = SettingsConfig(
             title="Register New Dataset",
@@ -660,7 +671,15 @@ class DatasetsPage(QWidget):
                     field_type=FieldType.DIRPATH,
                     default_value="",
                     placeholder="e.g., /home/corpora/timit_train",
-                    tooltip="Root directory containing speaker subdirectories",
+                    tooltip=(
+                        "Root folder with one subfolder per speaker. Each speaker "
+                        "folder holds that speaker's audio files (e.g. .wav).<br>"
+                        "If <i>Transcribed</i> is enabled, every audio file needs a "
+                        "matching .lab transcript with the same name.<br><br>"
+                        "speaker_01/<br>"
+                        "&nbsp;&nbsp;utt_001.wav<br>"
+                        "&nbsp;&nbsp;utt_001.lab"
+                    ),
                 ),
                 FieldConfig(
                     name="dataset_name",
@@ -684,28 +703,40 @@ class DatasetsPage(QWidget):
                     field_type=FieldType.COMBOBOX,
                     default_value=self.analysis_methods[0] if self.analysis_methods else "Default",
                     options=self.analysis_methods,
-                    tooltip="Select the analysis method for generating the dataset summary CSV",
+                    tooltip=analysis_tooltip,
                 ),
                 FieldConfig(
                     name="cache",
                     label="Cache Dataset",
                     field_type=FieldType.CHECKBOX,
                     default_value=False,
-                    tooltip="Copy entire dataset to storage (recommended for remote datasets)",
+                    tooltip=(
+                        "Copy the entire dataset into VoxKit's storage now. "
+                        "Recommended for remote or temporary datasets so processing "
+                        "no longer depends on the original files staying in place."
+                    ),
                 ),
                 FieldConfig(
                     name="anonymize",
                     label="De-identified",
                     field_type=FieldType.CHECKBOX,
                     default_value=False,
-                    tooltip="Has personally identifiable information been removed?",
+                    tooltip=(
+                        "Mark that personally identifiable information (e.g. speaker "
+                        "names) has already been removed from this dataset. This is a "
+                        "label only — it does not modify your files."
+                    ),
                 ),
                 FieldConfig(
                     name="transcribed",
                     label="Transcribed",
                     field_type=FieldType.CHECKBOX,
                     default_value=False,
-                    tooltip="Mark as already containing transcriptions",
+                    tooltip=(
+                        "The dataset already includes transcripts. Each audio file "
+                        "must have a matching .lab text file with the same name in "
+                        "the same folder."
+                    ),
                 ),
                 FieldConfig(
                     name="hand_alignments_path",
@@ -713,7 +744,11 @@ class DatasetsPage(QWidget):
                     field_type=FieldType.DIRPATH,
                     default_value="",
                     placeholder="Optional: directory of pre-existing TextGrids",
-                    tooltip="Optional directory containing hand-annotated TextGrid files",
+                    tooltip=(
+                        "Optional. Folder of pre-existing hand-annotated TextGrid "
+                        "files to compare against or correct alignments with. Leave "
+                        "empty if you don't have them."
+                    ),
                 ),
             ],
         )

--- a/tests/gui/test_settings_modal_tooltips.py
+++ b/tests/gui/test_settings_modal_tooltips.py
@@ -1,0 +1,51 @@
+"""Regression tests for tooltip handling in the settings-modal framework."""
+
+from PyQt6.QtWidgets import QFormLayout
+
+from voxkit.gui.frameworks.settings_modal import (
+    FieldConfig,
+    FieldType,
+    GenericDialog,
+    SettingsConfig,
+)
+
+
+def _build_dialog(qtbot, tooltip):
+    config = SettingsConfig(
+        title="Test",
+        dimensions=(400, 200),
+        apply_blur=False,
+        store_file="test_tooltips_settings.json",
+        fields=[
+            FieldConfig(
+                name="field",
+                label="Field Label",
+                field_type=FieldType.CHECKBOX,
+                default_value=False,
+                tooltip=tooltip,
+            ),
+        ],
+    )
+    dialog = GenericDialog(None, config=config)
+    qtbot.addWidget(dialog)
+    return dialog
+
+
+def _label_at(dialog, row):
+    item = dialog.form_layout.itemAt(row, QFormLayout.ItemRole.LabelRole)
+    return item.widget()
+
+
+class TestSettingsModalTooltips:
+    def test_tooltip_set_on_both_label_and_widget(self, qtbot):
+        dialog = _build_dialog(qtbot, "Helpful explanation")
+
+        # The input widget carries the tooltip...
+        assert dialog.field_widgets["field"].toolTip() == "Helpful explanation"
+        # ...and so does the field label, since users hover the label text.
+        assert _label_at(dialog, 0).toolTip() == "Helpful explanation"
+
+    def test_no_tooltip_leaves_label_empty(self, qtbot):
+        dialog = _build_dialog(qtbot, None)
+
+        assert _label_at(dialog, 0).toolTip() == ""


### PR DESCRIPTION
Closes #145

## Story

To increase usability, the **Register New Dataset** page should explain its fields via tooltips — especially the ones users find unclear (dataset structure, analysis method, caching, de-identified, transcribed, hand alignments path).

## What was actually wrong

The fields *did* pass a `tooltip` to `FieldConfig`, but the settings-modal framework added each row with a plain string label (`form_layout.addRow(field_config.label, ...)`). `QFormLayout` auto-creates that label and it receives **no tooltip** — so hovering the field's label text (the natural target) showed nothing, and the tooltip only appeared over the input widget. On top of that, the Dataset Path and Analysis Method hints were too terse to answer "how should this be formatted?" / "what do these options mean?".

## Changes

- **Framework fix** (`settings_modal/generic.py`): attach the field's tooltip to an explicit form `QLabel`, so the tooltip shows whether you hover the label **or** the input. This benefits every dialog built on the framework, not just this page.
- **Dataset Path**: now describes the speaker-subfolder layout and the `.lab` transcript requirement when *Transcribed* is enabled, with a small example tree.
- **Analysis Method**: the tooltip is now built dynamically from each analyzer's own `description`, so it lists what every option does (Default / Clip Duration Statistics / Audio Format Profile) and stays accurate as analyzers change.
- **Caching, De-identified, Transcribed, Hand Alignments Path**: expanded from one-liners into fuller explanations.

## Tests

- New `tests/gui/test_settings_modal_tooltips.py` locks in that the tooltip is set on both the label and the input widget.
- Full GUI suite passes; lint clean.
