### PR TITLE
Show an actionable message when no model is selected for alignment

### DIFF
--- a/src/voxkit/gui/pages/pipeline/prediction_stacker.py
+++ b/src/voxkit/gui/pages/pipeline/prediction_stacker.py
@@ -158,6 +158,26 @@ class PredictionStacker(BaseStacker):
             )
             return
 
+        selected_engine = self.model_panel.get_selected_engine()
+        if not selected_engine:
+            QMessageBox.warning(
+                self, "No Engine Selected", "Please select an alignment engine first."
+            )
+            return
+
+        # Guard against an unselected/empty model so the user gets an actionable
+        # message instead of a raw "Model 'None' for engine ... not found" error.
+        if not self.model_panel.get_selected_model_id():
+            engine_label = self.engines.get_engine(selected_engine).name()
+            QMessageBox.warning(
+                self,
+                "No Model Selected",
+                f"No model is selected for the {engine_label} engine.\n\n"
+                "Choose a model from the dropdown next to the engine. If the list "
+                "is empty, download or import a model from the Models page first.",
+            )
+            return
+
         print("Predict Alignments clicked!")
         print(f"Engine: {self.model_panel.get_selected_engine()}")
 

--- a/tests/gui/test_prediction_stacker_validation.py
+++ b/tests/gui/test_prediction_stacker_validation.py
@@ -1,0 +1,73 @@
+"""Tests for pre-flight validation in PredictionStacker.on_predict_alignments.
+
+These guard against passing an unselected dataset/engine/model to the engine,
+which otherwise surfaces as a raw "Model 'None' for engine ... not found" error.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from voxkit.gui.pages.pipeline import prediction_stacker
+from voxkit.gui.pages.pipeline.prediction_stacker import PredictionStacker
+
+
+class _WarningRecorder:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, parent, title, text, *args, **kwargs):
+        self.calls.append((title, text))
+
+
+@pytest.fixture
+def recorder(monkeypatch):
+    rec = _WarningRecorder()
+    monkeypatch.setattr(prediction_stacker.QMessageBox, "warning", rec)
+    return rec
+
+
+def _make_stacker(dataset_id, engine, model_id):
+    """Build a PredictionStacker with just the attributes the handler reads."""
+    stacker = PredictionStacker.__new__(PredictionStacker)
+    stacker.predict_dataset_dropdown = SimpleNamespace(current_id=lambda: dataset_id)
+    stacker.model_panel = SimpleNamespace(
+        get_selected_engine=lambda: engine,
+        get_selected_model_id=lambda: model_id,
+    )
+    stacker.engines = SimpleNamespace(
+        get_engine=lambda eid: SimpleNamespace(name=lambda: "Montreal Forced Aligner")
+    )
+    # If a guard is missed, starting a worker would explode here, failing the test.
+    stacker.worker = None
+    return stacker
+
+
+class TestPredictAlignmentsValidation:
+    def test_no_dataset_shows_warning(self, qtbot, recorder):
+        stacker = _make_stacker(dataset_id=None, engine="MFAENGINE", model_id="english")
+        stacker.on_predict_alignments()
+
+        assert recorder.calls == [
+            ("No Dataset Selected", "Please select a dataset from the dropdown.")
+        ]
+        assert stacker.worker is None
+
+    def test_no_engine_shows_warning(self, qtbot, recorder):
+        stacker = _make_stacker(dataset_id="ds1", engine=None, model_id="english")
+        stacker.on_predict_alignments()
+
+        assert recorder.calls[0][0] == "No Engine Selected"
+        assert stacker.worker is None
+
+    def test_no_model_shows_actionable_warning(self, qtbot, recorder):
+        stacker = _make_stacker(dataset_id="ds1", engine="MFAENGINE", model_id=None)
+        stacker.on_predict_alignments()
+
+        assert len(recorder.calls) == 1
+        title, text = recorder.calls[0]
+        assert title == "No Model Selected"
+        # Actionable: names the engine and points to where to get a model.
+        assert "Montreal Forced Aligner" in text
+        assert "Models page" in text
+        assert stacker.worker is None


### PR DESCRIPTION
Closes #147

## Problem

Clicking **Predict Alignments** without a model selected (none chosen, or none installed for the engine) passed `model_id=None` straight to the engine. That bubbled up as a raw, confusing error with no guidance:

> Model 'None' for engine "MFAENGINE" not found

## Root cause

`on_predict_alignments` validated the dataset but not the engine/model. `ModelSelectionPanel.get_selected_model_id()` returns `None` when no model is selected or when the engine has no models installed, and that `None` reached `MFAEngine.align()` → `get_model_metadata()`, which raises `FileNotFoundError("Model 'None' for engine ... not found")`.

## Fix

Add pre-flight validation in `on_predict_alignments`, mirroring the existing "No Dataset Selected" guard in the same handler. If no engine or model is selected, show an actionable `QMessageBox.warning` **before** the request reaches the engine:

> **No Model Selected**
> No model is selected for the Montreal Forced Aligner engine.
>
> Choose a model from the dropdown next to the engine. If the list is empty, download or import a model from the Models page first.

The message uses the engine's friendly `name()` (not the raw `MFAENGINE` id) and tells the user exactly what to do and where to get a model.

## Tests

New `tests/gui/test_prediction_stacker_validation.py` covers the dataset, engine, and model guards — asserting the correct warning is shown and no worker/align call is started.

Full GUI suite passes; `invoke format-check` clean.
