### PR TITLE
Remove shoutout footer from dataset and model pages

### DIFF
--- a/src/voxkit/gui/pages/datasets/datasets_page.py
+++ b/src/voxkit/gui/pages/datasets/datasets_page.py
@@ -123,12 +123,6 @@ class DatasetsPage(QWidget):
         main_layout.setSpacing(20)
         main_layout.setContentsMargins(0, 0, 0, 0)
 
-        # === Footer Credit ===
-        credit = QLabel("VoxKit by BrainBehaviorAnalyticsLab")
-        credit.setStyleSheet("color: #999; font-size: 10px; padding: 5px;")
-        credit.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        main_layout.addWidget(credit)
-
     def refresh_page(self):
         """Refresh the entire page content"""
         self.dataset_table.clearSelection()

--- a/src/voxkit/gui/pages/models/models_page.py
+++ b/src/voxkit/gui/pages/models/models_page.py
@@ -9,8 +9,7 @@ API
 
 from typing import Any
 
-from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QDialog, QLabel, QMessageBox
+from PyQt6.QtWidgets import QDialog, QMessageBox
 
 from voxkit.gui.frameworks.categorical_table.categorical_table import CategoricalTableWidget
 from voxkit.gui.frameworks.settings_modal import (
@@ -81,12 +80,6 @@ class ManageAlignersWidget(CategoricalTableWidget):
 
         self.layout().setSpacing(20)
         self.layout().setContentsMargins(0, 0, 0, 0)
-
-        # === Footer Credit ===
-        credit = QLabel("VoxKit by BrainBehaviorAnalyticsLab")
-        credit.setStyleSheet("color: #999; font-size: 10px; padding: 5px;")
-        credit.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.layout().addWidget(credit)
 
     def get_engines(self) -> list:
         """Return engines that have 'align' or 'train' tools available."""


### PR DESCRIPTION
Closes #110

Removes the "VoxKit by BrainBehaviorAnalyticsLab" footer credit label from the datasets and models pages.

## Changes
- Dropped the footer credit `QLabel` block at the bottom of `datasets_page.py` and `models_page.py`.
- Removed the now-unused `Qt` and `QLabel` imports from `models_page.py` (both were only referenced by the removed footer).